### PR TITLE
feat: configure MudBlazor services and providers (#13)

### DIFF
--- a/src/DevMetricsPro.Web/Components/App.razor
+++ b/src/DevMetricsPro.Web/Components/App.razor
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="/" />
     <link rel="stylesheet" href="@Assets["lib/bootstrap/dist/css/bootstrap.min.css"]" />
+    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
+    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link rel="stylesheet" href="@Assets["app.css"]" />
     <link rel="stylesheet" href="@Assets["DevMetricsPro.Web.styles.css"]" />
     <ImportMap />
@@ -14,6 +16,9 @@
 </head>
 
 <body>
+    <MudThemeProvider />
+    <MudPopoverProvider />
+    <MudDialogProvider />
     <Routes />
     <script src="_framework/blazor.web.js"></script>
 </body>

--- a/src/DevMetricsPro.Web/Components/_Imports.razor
+++ b/src/DevMetricsPro.Web/Components/_Imports.razor
@@ -8,3 +8,4 @@
 @using Microsoft.JSInterop
 @using DevMetricsPro.Web
 @using DevMetricsPro.Web.Components
+@using MudBlazor

--- a/src/DevMetricsPro.Web/Program.cs
+++ b/src/DevMetricsPro.Web/Program.cs
@@ -1,6 +1,7 @@
 using DevMetricsPro.Web.Components;
 using DevMetricsPro.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
+using MudBlazor.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -10,6 +11,8 @@ builder.Services.AddRazorComponents()
 
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+builder.Services.AddMudServices();
 
 var app = builder.Build();
 


### PR DESCRIPTION
Phase 6 Complete:
- Register MudBlazor services in Program.cs
- Add MudBlazor providers (Theme, Popover, Dialog) to App.razor
- Add MudBlazor CSS and Roboto font links
- Add @using MudBlazor to _Imports.razor
- Verify build succeeds with 0 warnings

Closes #13

<!-- GitHub auto-fills description from commits below -->

## ✅ Ready to Merge?
- [x] Builds successfully
- [ ] CI checks passing
- [x] Tested locally

