### PR TITLE
feat(auth): implement authentication API endpoints #36

### DIFF
--- a/.ai/helpers/README.md
+++ b/.ai/helpers/README.md
@@ -1,0 +1,184 @@
+# DevMetrics Pro - Helper Scripts
+
+This directory contains utility scripts for testing and development.
+
+## 📁 Scripts
+
+### 🧪 `test-auth-endpoints.ps1`
+**Purpose**: Test both Register and Login API endpoints in one go.
+
+**Usage**:
+```powershell
+# Default test (uses testuser@devmetrics.com)
+.\test-auth-endpoints.ps1
+
+# Customize test user by editing variables at top of script
+```
+
+**What it does**:
+- ✅ Tests `/api/auth/register` endpoint
+- ✅ Tests `/api/auth/login` endpoint
+- ✅ Shows response with tokens
+- ✅ Handles errors gracefully
+
+---
+
+### 🔍 `decode-jwt-token.ps1`
+**Purpose**: Decode and inspect JWT tokens.
+
+**Usage**:
+```powershell
+# Interactive mode (prompts for token)
+.\decode-jwt-token.ps1
+
+# Direct mode (pass token as parameter)
+.\decode-jwt-token.ps1 -token "eyJhbGci..."
+```
+
+**What it does**:
+- ✅ Decodes JWT header
+- ✅ Decodes JWT payload (claims)
+- ✅ Shows token expiration time
+- ✅ Calculates time remaining
+- ✅ Validates token structure
+
+---
+
+### 🎯 `test-single-endpoint.ps1`
+**Purpose**: Test individual endpoints with custom data.
+
+**Usage**:
+```powershell
+# Test register
+.\test-single-endpoint.ps1 -endpoint register -email "user@test.com" -password "Pass1234!"
+
+# Test login
+.\test-single-endpoint.ps1 -endpoint login -email "user@test.com" -password "Pass1234!"
+
+# Interactive mode (prompts for missing parameters)
+.\test-single-endpoint.ps1 -endpoint register
+```
+
+**What it does**:
+- ✅ Tests single endpoint with custom credentials
+- ✅ Copies JWT token to clipboard automatically
+- ✅ Shows detailed error messages
+- ✅ Supports interactive mode
+
+---
+
+## 🚀 Quick Start
+
+1. **Start the application**:
+   ```powershell
+   dotnet run --project src/DevMetricsPro.Web
+   ```
+
+2. **Open PowerShell in this directory** (`.ai/helpers/`)
+
+3. **Run a test script**:
+   ```powershell
+   # Test both endpoints
+   .\test-auth-endpoints.ps1
+   
+   # Or test a specific endpoint
+   .\test-single-endpoint.ps1 -endpoint register -email "test@dev.com" -password "Test1234!"
+   ```
+
+4. **Decode the JWT token**:
+   ```powershell
+   # The token is in your clipboard after running test-single-endpoint.ps1
+   .\decode-jwt-token.ps1
+   # Then paste the token when prompted
+   ```
+
+---
+
+## 💡 Tips
+
+### Token in Clipboard
+After running `test-single-endpoint.ps1`, the JWT token is automatically copied to your clipboard! You can:
+- Paste it into `decode-jwt-token.ps1` to inspect it
+- Use it in Postman/Insomnia for testing protected endpoints
+- Store it for manual testing
+
+### Custom Base URL
+All scripts default to `http://localhost:5234`. If your app runs on a different port, modify the `$baseUrl` variable.
+
+### Execution Policy
+If PowerShell blocks the scripts, run:
+```powershell
+Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+```
+
+Or run scripts with bypass flag:
+```powershell
+powershell -ExecutionPolicy Bypass -File .\test-auth-endpoints.ps1
+```
+
+---
+
+## 🔧 Customization
+
+### Changing Test Credentials
+Edit `test-auth-endpoints.ps1` and modify these lines:
+```powershell
+$testEmail = "your-email@example.com"
+$testPassword = "YourPassword123!"
+```
+
+### Changing Base URL
+If your app runs on a different port:
+```powershell
+$baseUrl = "https://localhost:7270"
+```
+
+---
+
+## 📝 Notes
+
+- Scripts are designed for **Development** environment only
+- JWT tokens expire after 60 minutes (configurable in `appsettings.json`)
+- Make sure the application is running before executing scripts
+- Scripts handle errors and show detailed error messages
+
+---
+
+## 🎓 Learning Resources
+
+### Understanding the Scripts
+- **Invoke-RestMethod**: PowerShell cmdlet for HTTP requests
+- **ConvertTo-Json**: Converts PowerShell objects to JSON
+- **Base64 Decoding**: JWT tokens are Base64URL encoded
+- **Error Handling**: try-catch blocks for robust error handling
+
+### JWT Structure
+```
+Header.Payload.Signature
+│      │       └─ HMAC-SHA256 signature (encrypted)
+│      └─ Claims (user data, expiration, etc.)
+└─ Algorithm and token type
+```
+
+All three parts are Base64URL encoded!
+
+---
+
+## 🆘 Troubleshooting
+
+### "Connection refused"
+- ✅ Make sure the application is running
+- ✅ Check the port number in `$baseUrl`
+
+### "Invalid token format"
+- ✅ Make sure you copied the entire token
+- ✅ Token should have exactly 2 dots (3 parts)
+
+### "User already exists"
+- ✅ Change the email in test script
+- ✅ Or use the login endpoint instead
+
+---
+
+**Happy Testing! 🚀**
+

--- a/.ai/helpers/decode-jwt-token.ps1
+++ b/.ai/helpers/decode-jwt-token.ps1
@@ -1,0 +1,92 @@
+# DevMetrics Pro - JWT Token Decoder
+# This script decodes a JWT token and displays its contents
+
+param(
+    [Parameter(Mandatory=$false)]
+    [string]$token = ""
+)
+
+# If no token provided, prompt user
+if ([string]::IsNullOrEmpty($token)) {
+    Write-Host "Enter JWT token to decode:" -ForegroundColor Yellow
+    $token = Read-Host
+}
+
+Write-Host ""
+Write-Host "================================" -ForegroundColor Cyan
+Write-Host "JWT Token Decoder" -ForegroundColor Cyan
+Write-Host "================================" -ForegroundColor Cyan
+Write-Host ""
+
+# Split token into parts
+$parts = $token.Split('.')
+
+if ($parts.Length -ne 3) {
+    Write-Host "❌ Invalid JWT token format" -ForegroundColor Red
+    Write-Host "Expected format: Header.Payload.Signature" -ForegroundColor Yellow
+    exit 1
+}
+
+try {
+    # Decode header
+    Write-Host "📋 HEADER:" -ForegroundColor Yellow
+    $headerPadded = $parts[0].Replace('-', '+').Replace('_', '/')
+    $headerPadded = $headerPadded.PadRight($headerPadded.Length + (4 - $headerPadded.Length % 4) % 4, '=')
+    $headerJson = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($headerPadded))
+    $header = $headerJson | ConvertFrom-Json
+    $header | Format-List
+    Write-Host ""
+
+    # Decode payload
+    Write-Host "🔐 PAYLOAD (Claims):" -ForegroundColor Yellow
+    $payloadPadded = $parts[1].Replace('-', '+').Replace('_', '/')
+    $payloadPadded = $payloadPadded.PadRight($payloadPadded.Length + (4 - $payloadPadded.Length % 4) % 4, '=')
+    $payloadJson = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($payloadPadded))
+    $payload = $payloadJson | ConvertFrom-Json
+
+    # Pretty print claims
+    $payload | Get-Member -MemberType NoteProperty | ForEach-Object {
+        $name = $_.Name
+        $value = $payload.$name
+        
+        # Convert Unix timestamp for 'exp' claim
+        if ($name -eq "exp") {
+            try {
+                $expDate = [DateTimeOffset]::FromUnixTimeSeconds($value).DateTime.ToLocalTime()
+                $now = Get-Date
+                $timeLeft = $expDate - $now
+                
+                Write-Host "  $name : $value" -ForegroundColor White
+                Write-Host "    └─ Expires: $expDate" -ForegroundColor Gray
+                
+                if ($timeLeft.TotalSeconds -gt 0) {
+                    Write-Host "    └─ Time left: $([math]::Floor($timeLeft.TotalMinutes)) minutes" -ForegroundColor Green
+                } else {
+                    Write-Host "    └─ ⚠️  Token EXPIRED!" -ForegroundColor Red
+                }
+            } catch {
+                Write-Host "  $name : $value" -ForegroundColor White
+            }
+        } else {
+            Write-Host "  $name : $value" -ForegroundColor White
+        }
+    }
+
+    Write-Host ""
+    Write-Host "🔒 SIGNATURE:" -ForegroundColor Yellow
+    Write-Host "  $($parts[2].Substring(0, [Math]::Min(50, $parts[2].Length)))..." -ForegroundColor Gray
+    Write-Host "  (Signature is encrypted - cannot be decoded)" -ForegroundColor Gray
+    Write-Host ""
+
+    Write-Host "✅ Token structure is valid" -ForegroundColor Green
+    Write-Host "================================" -ForegroundColor Cyan
+    
+} catch {
+    Write-Host "❌ Error decoding token: $($_.Exception.Message)" -ForegroundColor Red
+    Write-Host ""
+    Write-Host "Make sure you provided a valid JWT token." -ForegroundColor Yellow
+}
+
+Write-Host ""
+Write-Host "💡 TIP: You can pass the token as a parameter: .\decode-jwt-token.ps1 -token 'your-token-here'" -ForegroundColor Yellow
+

--- a/.ai/helpers/test-auth-endpoints.ps1
+++ b/.ai/helpers/test-auth-endpoints.ps1
@@ -1,0 +1,101 @@
+# DevMetrics Pro - Authentication API Testing Script
+# This script tests both Register and Login endpoints
+
+Write-Host "================================" -ForegroundColor Cyan
+Write-Host "Testing DevMetrics Pro Auth API" -ForegroundColor Cyan
+Write-Host "================================" -ForegroundColor Cyan
+Write-Host ""
+
+# Configuration
+$baseUrl = "http://localhost:5234"
+$testEmail = "testuser@devmetrics.com"
+$testPassword = "TestUser1234!"
+
+# Test 1: Register
+Write-Host "1. Testing REGISTER endpoint..." -ForegroundColor Yellow
+$registerBody = @{
+    email = $testEmail
+    password = $testPassword
+    confirmPassword = $testPassword
+} | ConvertTo-Json
+
+try {
+    $registerResponse = Invoke-RestMethod -Uri "$baseUrl/api/auth/register" `
+        -Method POST `
+        -Body $registerBody `
+        -ContentType "application/json"
+    
+    Write-Host "✅ Register SUCCESS!" -ForegroundColor Green
+    Write-Host "Email: $($registerResponse.email)" -ForegroundColor White
+    Write-Host "Display Name: $($registerResponse.displayName)" -ForegroundColor White
+    Write-Host "Token: $($registerResponse.token.Substring(0, 50))..." -ForegroundColor White
+    Write-Host "Expires: $($registerResponse.expiresAt)" -ForegroundColor White
+    Write-Host ""
+    
+    $token = $registerResponse.token
+} catch {
+    Write-Host "❌ Register FAILED!" -ForegroundColor Red
+    Write-Host $_.Exception.Message -ForegroundColor Red
+    
+    # Try to get detailed error
+    if ($_.Exception.Response) {
+        try {
+            $reader = New-Object System.IO.StreamReader($_.Exception.Response.GetResponseStream())
+            $responseBody = $reader.ReadToEnd()
+            Write-Host "Error Details: $responseBody" -ForegroundColor Red
+        } catch {
+            # Ignore if we can't read response
+        }
+    }
+    Write-Host ""
+}
+
+# Wait a moment
+Start-Sleep -Seconds 1
+
+# Test 2: Login
+Write-Host "2. Testing LOGIN endpoint..." -ForegroundColor Yellow
+$loginBody = @{
+    email = $testEmail
+    password = $testPassword
+    rememberMe = $false
+} | ConvertTo-Json
+
+try {
+    $loginResponse = Invoke-RestMethod -Uri "$baseUrl/api/auth/login" `
+        -Method POST `
+        -Body $loginBody `
+        -ContentType "application/json"
+    
+    Write-Host "✅ Login SUCCESS!" -ForegroundColor Green
+    Write-Host "Email: $($loginResponse.email)" -ForegroundColor White
+    Write-Host "Display Name: $($loginResponse.displayName)" -ForegroundColor White
+    Write-Host "Token: $($loginResponse.token.Substring(0, 50))..." -ForegroundColor White
+    Write-Host "Expires: $($loginResponse.expiresAt)" -ForegroundColor White
+    Write-Host ""
+    
+    $token = $loginResponse.token
+} catch {
+    Write-Host "❌ Login FAILED!" -ForegroundColor Red
+    Write-Host $_.Exception.Message -ForegroundColor Red
+    
+    # Try to get detailed error
+    if ($_.Exception.Response) {
+        try {
+            $reader = New-Object System.IO.StreamReader($_.Exception.Response.GetResponseStream())
+            $responseBody = $reader.ReadToEnd()
+            Write-Host "Error Details: $responseBody" -ForegroundColor Red
+        } catch {
+            # Ignore if we can't read response
+        }
+    }
+    Write-Host ""
+}
+
+Write-Host "================================" -ForegroundColor Cyan
+Write-Host "Testing Complete!" -ForegroundColor Cyan
+Write-Host "================================" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "💡 TIP: You can customize the test user by editing the variables at the top of this script" -ForegroundColor Yellow
+Write-Host "💡 TIP: Make sure the application is running before executing this script" -ForegroundColor Yellow
+

--- a/.ai/helpers/test-single-endpoint.ps1
+++ b/.ai/helpers/test-single-endpoint.ps1
@@ -1,0 +1,142 @@
+# DevMetrics Pro - Single Endpoint Tester
+# Flexible script for testing individual endpoints
+
+param(
+    [Parameter(Mandatory=$true)]
+    [ValidateSet('register', 'login')]
+    [string]$endpoint,
+    
+    [Parameter(Mandatory=$false)]
+    [string]$email = "",
+    
+    [Parameter(Mandatory=$false)]
+    [string]$password = "",
+    
+    [Parameter(Mandatory=$false)]
+    [string]$baseUrl = "http://localhost:5234"
+)
+
+# Prompt for missing parameters
+if ([string]::IsNullOrEmpty($email)) {
+    $email = Read-Host "Enter email"
+}
+
+if ([string]::IsNullOrEmpty($password)) {
+    $password = Read-Host "Enter password" -AsSecureString
+    $password = [Runtime.InteropServices.Marshal]::PtrToStringAuto(
+        [Runtime.InteropServices.Marshal]::SecureStringToBSTR($password)
+    )
+}
+
+Write-Host ""
+Write-Host "================================" -ForegroundColor Cyan
+Write-Host "Testing $($endpoint.ToUpper()) endpoint" -ForegroundColor Cyan
+Write-Host "================================" -ForegroundColor Cyan
+Write-Host ""
+
+if ($endpoint -eq "register") {
+    # Test Register
+    $body = @{
+        email = $email
+        password = $password
+        confirmPassword = $password
+    } | ConvertTo-Json
+    
+    try {
+        Write-Host "Sending request to: $baseUrl/api/auth/register" -ForegroundColor Gray
+        Write-Host ""
+        
+        $response = Invoke-RestMethod -Uri "$baseUrl/api/auth/register" `
+            -Method POST `
+            -Body $body `
+            -ContentType "application/json" `
+            -ErrorAction Stop
+        
+        Write-Host "✅ REGISTER SUCCESS!" -ForegroundColor Green
+        Write-Host ""
+        Write-Host "Response:" -ForegroundColor Yellow
+        Write-Host "  Email: $($response.email)" -ForegroundColor White
+        Write-Host "  Display Name: $($response.displayName)" -ForegroundColor White
+        Write-Host "  Expires At: $($response.expiresAt)" -ForegroundColor White
+        Write-Host "  Token: $($response.token.Substring(0, 50))..." -ForegroundColor White
+        Write-Host "  Refresh Token: $($response.refreshToken.Substring(0, 20))..." -ForegroundColor White
+        Write-Host ""
+        Write-Host "💾 Full token saved to clipboard!" -ForegroundColor Green
+        
+        # Copy token to clipboard
+        $response.token | Set-Clipboard
+        
+    } catch {
+        Write-Host "❌ REGISTER FAILED!" -ForegroundColor Red
+        Write-Host ""
+        Write-Host "Status Code: $($_.Exception.Response.StatusCode.value__)" -ForegroundColor Red
+        
+        # Try to get detailed error
+        try {
+            $reader = New-Object System.IO.StreamReader($_.Exception.Response.GetResponseStream())
+            $responseBody = $reader.ReadToEnd()
+            Write-Host "Error Details:" -ForegroundColor Red
+            Write-Host $responseBody -ForegroundColor Yellow
+        } catch {
+            Write-Host "Error: $($_.Exception.Message)" -ForegroundColor Yellow
+        }
+    }
+    
+} elseif ($endpoint -eq "login") {
+    # Test Login
+    $body = @{
+        email = $email
+        password = $password
+        rememberMe = $false
+    } | ConvertTo-Json
+    
+    try {
+        Write-Host "Sending request to: $baseUrl/api/auth/login" -ForegroundColor Gray
+        Write-Host ""
+        
+        $response = Invoke-RestMethod -Uri "$baseUrl/api/auth/login" `
+            -Method POST `
+            -Body $body `
+            -ContentType "application/json" `
+            -ErrorAction Stop
+        
+        Write-Host "✅ LOGIN SUCCESS!" -ForegroundColor Green
+        Write-Host ""
+        Write-Host "Response:" -ForegroundColor Yellow
+        Write-Host "  Email: $($response.email)" -ForegroundColor White
+        Write-Host "  Display Name: $($response.displayName)" -ForegroundColor White
+        Write-Host "  Expires At: $($response.expiresAt)" -ForegroundColor White
+        Write-Host "  Token: $($response.token.Substring(0, 50))..." -ForegroundColor White
+        Write-Host "  Refresh Token: $($response.refreshToken.Substring(0, 20))..." -ForegroundColor White
+        Write-Host ""
+        Write-Host "💾 Full token saved to clipboard!" -ForegroundColor Green
+        
+        # Copy token to clipboard
+        $response.token | Set-Clipboard
+        
+    } catch {
+        Write-Host "❌ LOGIN FAILED!" -ForegroundColor Red
+        Write-Host ""
+        Write-Host "Status Code: $($_.Exception.Response.StatusCode.value__)" -ForegroundColor Red
+        
+        # Try to get detailed error
+        try {
+            $reader = New-Object System.IO.StreamReader($_.Exception.Response.GetResponseStream())
+            $responseBody = $reader.ReadToEnd()
+            Write-Host "Error Details:" -ForegroundColor Red
+            Write-Host $responseBody -ForegroundColor Yellow
+        } catch {
+            Write-Host "Error: $($_.Exception.Message)" -ForegroundColor Yellow
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "================================" -ForegroundColor Cyan
+Write-Host "Testing Complete!" -ForegroundColor Cyan
+Write-Host "================================" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "💡 EXAMPLES:" -ForegroundColor Yellow
+Write-Host "  .\test-single-endpoint.ps1 -endpoint register -email 'user@test.com' -password 'Pass1234!'" -ForegroundColor Gray
+Write-Host "  .\test-single-endpoint.ps1 -endpoint login -email 'user@test.com' -password 'Pass1234!'" -ForegroundColor Gray
+

--- a/.ai/sprints/sprint1/sprint-log.md
+++ b/.ai/sprints/sprint1/sprint-log.md
@@ -303,17 +303,88 @@ Solid foundation with domain entities, database, authentication, and basic UI
 
 ---
 
-### Day 8 - __________
+### Day 8 - October 20, 2025 (Continued)
 **Phases completed**:
-- [ ] Phase 1.8: Authentication API Endpoints
+- [x] Phase 1.8: Authentication API Endpoints ✅
 
 **What I learned**:
-- 
-- 
 
-**Time spent**: ___ hours  
-**Blockers**: None / [describe]  
+**Phase 1.8 - Authentication API Endpoints:**
+- Created Auth DTOs in Application layer:
+  - `RegisterRequest` with Email, Password, ConfirmPassword validation
+  - `LoginRequest` with Email, Password, RememberMe fields
+  - `AuthResponse` with Token, Email, DisplayName, ExpiresAt, RefreshToken
+- Used **Data Annotations** for validation: `[Required]`, `[EmailAddress]`, `[Compare]`
+- Created `AuthController` API controller with `[ApiController]` and `[Route("api/[controller]")]`
+- Injected Identity services: `UserManager<ApplicationUser>`, `SignInManager<ApplicationUser>`
+- Implemented **POST /api/auth/register** endpoint:
+  - Validates model state automatically (thanks to `[ApiController]`)
+  - Creates new `ApplicationUser` with email as username
+  - Uses `UserManager.CreateAsync(user, password)` for secure password hashing
+  - Returns JWT token immediately after successful registration
+- Implemented **POST /api/auth/login** endpoint:
+  - Finds user by email with `UserManager.FindByEmailAsync()`
+  - Validates password with `SignInManager.CheckPasswordSignInAsync()`
+  - Handles account lockout after failed attempts (security feature)
+  - Updates `LastLoginAt` timestamp on successful login
+  - Returns JWT token with user information
+- Used `[ProducesResponseType]` attributes for OpenAPI/Swagger documentation
+- Learned about **UserManager**: High-level API for user CRUD operations
+- Learned about **SignInManager**: Handles password validation and sign-in logic
+- Fixed role assignment issue: Commented out `AddToRoleAsync()` (roles not created yet)
+- Refactored to remove **magic numbers**: Used `Jwt:ExpirationMinutes` from config
+- Injected `IConfiguration` to read JWT expiration setting
+- Tested endpoints with PowerShell `Invoke-RestMethod`:
+  - ✅ Register: Successfully created user and returned JWT
+  - ✅ Login: Successfully authenticated and returned JWT
+- Decoded JWT token to verify claims:
+  - User ID (nameidentifier)
+  - Email (emailaddress)
+  - Username (name)
+  - Expiration (exp) - 60 minutes
+  - Issuer and Audience
+- Verified token expiration matches configuration (60 minutes)
+
+**Key Concepts:**
+- **API Controller**: Special controller for REST APIs (no views, JSON responses)
+- **Model Validation**: Automatic validation with Data Annotations
+- **UserManager<T>**: Identity service for user management (create, find, update)
+- **SignInManager<T>**: Identity service for authentication (password check, lockout)
+- **Password Hashing**: Identity automatically hashes passwords with PBKDF2
+- **Account Lockout**: Temporary lock after failed login attempts (brute-force protection)
+- **Bearer Token**: JWT sent in Authorization header for API authentication
+- **Claims**: User information embedded in JWT (stateless authentication)
+- **Model State**: ASP.NET Core validates incoming data automatically
+- **Action Results**: `Ok()`, `BadRequest()`, `Unauthorized()` return proper HTTP status codes
+
+**Challenges:**
+- Initial 500 error: Role "User" doesn't exist yet
+- Solution: Commented out role assignment for now (will implement role seeding later)
+- `CheckPasswordSignInAsync` signature error: Had extra `RememberMe` parameter
+- Solution: Removed incorrect parameter (RememberMe is for cookie auth, not password check)
+- Magic number in expiration: Hardcoded 30 minutes instead of config value
+- Solution: Injected IConfiguration and read `Jwt:ExpirationMinutes`
+- Process locking during rebuild: App was still running
+- Solution: Killed process with `taskkill /F /PID`
+
+**Testing:**
+- Created PowerShell test scripts for quick endpoint testing
+- Successfully registered new user: `finaltest@devmetrics.com`
+- Successfully logged in and received new JWT token
+- Decoded JWT to verify all claims present and correct
+- Verified token expiration time matches configuration
+- Cleaned up test scripts after verification
+
+**Time spent**: ~2 hours  
+**Blockers**: Role seeding needed (minor - not blocking MVP)  
 **Notes**: 
+- Authentication API fully functional! ✅
+- Both register and login endpoints working perfectly
+- JWT tokens generated with correct claims and expiration
+- Ready to move to Blazor UI (Phase 1.9)
+- Note: Role management will be added in future phase
+- Controllers properly use configuration instead of magic numbers
+- Authentication flow is complete and secure 
 
 ---
 
@@ -384,7 +455,7 @@ Solid foundation with domain entities, database, authentication, and basic UI
 - [x] Repository pattern with Unit of Work
 - [x] ASP.NET Core Identity setup ✅
 - [x] JWT authentication functional ✅
-- [ ] Auth API endpoints (register/login)
+- [x] Auth API endpoints (register/login) ✅
 - [ ] Basic Blazor UI with MudBlazor
 - [x] Logging configured
 - [x] Error handling middleware

--- a/src/DevMetricsPro.Application/DTOs/Auth/AuthResponse.cs
+++ b/src/DevMetricsPro.Application/DTOs/Auth/AuthResponse.cs
@@ -1,0 +1,32 @@
+namespace DevMetricsPro.Application.DTOs.Auth;
+
+/// <summary>
+/// Response model for successful authentication
+/// </summary>
+public class AuthResponse
+{
+    /// <summary>
+    /// JWT access token
+    /// </summary>
+    public string Token { get; set; } = string.Empty;
+
+    /// <summary>
+    /// User's email address
+    /// </summary>
+    public string Email { get; set; } = string.Empty;
+
+    /// <summary>
+    /// User's display name (if available)
+    /// </summary>
+    public string? DisplayName { get; set; }
+
+    /// <summary>
+    /// Token expiration time (UTC)
+    /// </summary>
+    public DateTime ExpiresAt { get; set; }
+
+    /// <summary>
+    /// Optional: Refresh token for getting new access tokens
+    /// </summary>
+    public string? RefreshToken { get; set; }
+}

--- a/src/DevMetricsPro.Application/DTOs/Auth/LoginRequest.cs
+++ b/src/DevMetricsPro.Application/DTOs/Auth/LoginRequest.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DevMetricsPro.Application.DTOs.Auth;
+
+/// <summary>
+/// Request model for user login
+/// </summary>
+public class LoginRequest
+{
+    /// <summary>
+    /// User's email address
+    /// </summary>
+    [Required(ErrorMessage = "Email is required")]
+    [EmailAddress(ErrorMessage = "Invalid email format")]
+    public string Email { get; set; } = string.Empty;
+
+    /// <summary>
+    /// User's password
+    /// </summary>
+    [Required(ErrorMessage = "Password is required")]
+    public string Password { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional: Remember me for extended session
+    /// </summary>
+    public bool RememberMe { get; set; } = false;
+}

--- a/src/DevMetricsPro.Application/DTOs/Auth/RegisterRequest.cs
+++ b/src/DevMetricsPro.Application/DTOs/Auth/RegisterRequest.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DevMetricsPro.Application.DTOs.Auth;
+
+public class RegisterRequest
+{
+    /// <summary>
+    /// User's email address (used as username)
+    /// </summary>
+    [Required(ErrorMessage = "Email is required")]
+    [EmailAddress(ErrorMessage = "Invalid email format")]
+    public string Email { get; set; } = string.Empty;
+
+    /// <summary>
+    /// User's password
+    /// </summary>
+    [Required(ErrorMessage = "Password is required")]
+    [MinLength(8, ErrorMessage = "Password must be at least 8 characters long")]
+    public string Password { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Password confirmation (must much Password)
+    /// </summary>
+    [Required(ErrorMessage = "Password confirmation is required")]
+    [Compare(nameof(Password), ErrorMessage = "Passwords do not match")]
+    public string ConfirmPassword { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional display name for the user
+    /// </summary>
+    [StringLength(100, ErrorMessage = "Dispal name cannot exeed 100 characters")]
+    public string? DisplayName { get; set; }
+}

--- a/src/DevMetricsPro.Web/Controllers/AuthController.cs
+++ b/src/DevMetricsPro.Web/Controllers/AuthController.cs
@@ -1,0 +1,147 @@
+using DevMetricsPro.Application.DTOs.Auth;
+using DevMetricsPro.Application.Interfaces;
+using DevMetricsPro.Core.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DevMetricsPro.Web.Controllers;
+
+/// <summary>
+/// API controller for authentication operations
+/// </summary>
+[ApiController]
+[Route("api/[controller]")]
+public class AuthController : ControllerBase
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly SignInManager<ApplicationUser> _signInManager;
+    private readonly IJwtService _jwtService;
+    private readonly ILogger<AuthController> _logger;
+    private readonly IConfiguration _configuration;
+
+    public AuthController(
+        UserManager<ApplicationUser> userManager,
+        SignInManager<ApplicationUser> signInManager,
+        IJwtService jwtService,
+        ILogger<AuthController> logger,
+        IConfiguration configuration
+    )
+    {
+        _userManager = userManager;
+        _signInManager = signInManager;
+        _jwtService = jwtService;
+        _logger = logger;
+        _configuration = configuration;
+    }
+
+    /// <summary>
+    /// Register a new user
+    /// </summary>
+    /// <param name="request">Registration details</param>
+    /// <returns>JWT token and user information</returns>
+    [HttpPost("register")]
+    [ProducesResponseType(typeof(AuthResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<AuthResponse>> Register([FromBody] RegisterRequest request)
+    {
+        // Check if the model is valid
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        // Create a new user
+        var user = new ApplicationUser
+        {
+            UserName = request.Email,
+            Email = request.Email,
+            CreatedAt = DateTime.UtcNow,
+        };
+
+        // Attempt to create the user
+        var result = await _userManager.CreateAsync(user, request.Password);
+
+        if (!result.Succeeded)
+        {
+            foreach (var error in result.Errors) ModelState.AddModelError(string.Empty, error.Description);
+            return BadRequest(ModelState);
+        }
+
+        // TODO: Add default role after implementing role seeding
+        // await _userManager.AddToRoleAsync(user, "User");
+
+        // Generate JWT token
+        var roles = await _userManager.GetRolesAsync(user);
+        var token = _jwtService.GenerateToken(user, roles);
+        var refreshToken = await _jwtService.GenerateRefreshTokenAsync();
+
+        _logger.LogInformation("User {Email} registered successfully", user.Email);
+
+        var expirationMinutes = Convert.ToDouble(_configuration["Jwt:ExpirationMinutes"]);
+        
+        return Ok(new AuthResponse
+        {
+            Token = token,
+            Email = user.Email!,
+            DisplayName = user.UserName,
+            ExpiresAt = DateTime.UtcNow.AddMinutes(expirationMinutes),
+            RefreshToken = refreshToken
+        });        
+    }
+
+    /// <summary>
+    /// Login a user
+    /// </summary>
+    /// <param name="request">Login credentials</param>
+    /// <returns>JWT token and user information</returns>
+    [HttpPost("login")]
+    [ProducesResponseType(typeof(AuthResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<AuthResponse>> Login([FromBody] LoginRequest request)
+    {
+        // Check if the model is valid
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        // Find model by email
+        var user = await _userManager.FindByEmailAsync(request.Email);
+        if (user == null) return Unauthorized("Invalid e-mail or password");
+
+        // Check password
+        var result = await _signInManager.CheckPasswordSignInAsync(
+            user, 
+            request.Password, 
+            lockoutOnFailure: true
+        );
+
+        if (!result.Succeeded)
+        {
+            if (result.IsLockedOut)
+            {
+                _logger.LogWarning("User {Email} has been locked out", user.Email);
+                return Unauthorized(new { message = "Account locked due to multiple failed attempts"});
+            }
+            return Unauthorized(new { message = "Invalid e-mail or password"});
+        }
+
+        // Update last login time
+        user.LastLoginAt = DateTime.UtcNow;
+        await _userManager.UpdateAsync(user);
+
+        // Generate JWT token
+        var roles = await _userManager.GetRolesAsync(user);
+        var token = _jwtService.GenerateToken(user, roles);
+        var refreshToken = await _jwtService.GenerateRefreshTokenAsync();
+
+        _logger.LogInformation("User {Email} logged in successfully", user.Email);
+
+        var expirationMinutes = Convert.ToDouble(_configuration["Jwt:ExpirationMinutes"]);
+        
+        return Ok(new AuthResponse
+        {
+            Token = token,
+            Email = user.Email!,
+            DisplayName = user.UserName,
+            ExpiresAt = DateTime.UtcNow.AddMinutes(expirationMinutes),
+            RefreshToken = refreshToken
+        });
+    }
+
+
+}

--- a/src/DevMetricsPro.Web/Program.cs
+++ b/src/DevMetricsPro.Web/Program.cs
@@ -77,6 +77,9 @@ try
 
     builder.Services.AddMudServices();
 
+    // API Controllers
+    builder.Services.AddControllers();
+
     // Jwt Service
     builder.Services.AddScoped<IJwtService, JwtService>();
 
@@ -127,6 +130,8 @@ try
     app.MapStaticAssets();
     app.MapRazorComponents<App>()
         .AddInteractiveServerRenderMode();
+
+    app.MapControllers();
 
     app.Run();
 }


### PR DESCRIPTION
- Add RegisterRequest, LoginRequest, AuthResponse DTOs
- Create AuthController with register and login endpoints
- Implement JWT token generation on successful auth
- Add account lockout protection
- Refactor to use config values instead of magic numbers
- Add PowerShell testing scripts in .ai/helpers/
- Test both endpoints successfully
- Update sprint log for Phase 1.8

Relates to #36

<!-- GitHub auto-fills description from commits below -->

## ✅ Ready to Merge?
- [x] Builds successfully
- [x] CI checks passing
- [x] Tested locally

