### PR TITLE
feat(ui): add professional reusable UI components (#63)

### DIFF
--- a/src/DevMetricsPro.Web/Components/Shared/DataPanel.razor
+++ b/src/DevMetricsPro.Web/Components/Shared/DataPanel.razor
@@ -1,0 +1,39 @@
+@* Professional data panel component with header and actions *@
+
+<div class="panel">
+    <div class="panel-header">
+        <div class="panel-title">@Title</div>
+        
+        @if (Actions != null)
+        {
+            <div class="panel-actions">
+                @Actions
+            </div>
+        }
+    </div>
+    
+    <div class="panel-body">
+        @ChildContent
+    </div>
+</div>
+
+@code {
+    /// <summary>
+    /// The title displayed in the panel header
+    /// </summary>
+    [Parameter]
+    public string Title { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// The main content of the panel
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+    
+    /// <summary>
+    /// Optional action buttons in the header (e.g., Export, Refresh)
+    /// </summary>
+    [Parameter]
+    public RenderFragment? Actions { get; set; }
+}
+

--- a/src/DevMetricsPro.Web/Components/Shared/DataTable.razor
+++ b/src/DevMetricsPro.Web/Components/Shared/DataTable.razor
@@ -1,0 +1,62 @@
+@typeparam TItem
+@* Professional data table component with generic type support *@
+
+<table class="data-table">
+    <thead>
+        <tr>
+            @TableHeader
+        </tr>
+    </thead>
+    <tbody>
+        @if (Items == null || !Items.Any())
+        {
+            <tr>
+                <td colspan="100" style="text-align: center; padding: var(--spacing-xl); color: var(--text-tertiary);">
+                    @EmptyMessage
+                </td>
+            </tr>
+        }
+        else
+        {
+            @foreach (var item in Items)
+            {
+                <tr @onclick="() => OnRowClick.InvokeAsync(item)" style="@(OnRowClick.HasDelegate ? "cursor: pointer;" : "")">
+                    @RowTemplate?.Invoke(item)
+                </tr>
+            }
+        }
+    </tbody>
+</table>
+
+@code {
+    /// <summary>
+    /// The items to display in the table
+    /// </summary>
+    [Parameter]
+    public IEnumerable<TItem>? Items { get; set; }
+    
+    /// <summary>
+    /// Template for table header (th elements)
+    /// </summary>
+    [Parameter]
+    public RenderFragment? TableHeader { get; set; }
+    
+    /// <summary>
+    /// Template for each row (td elements)
+    /// </summary>
+    [Parameter]
+    public RenderFragment<TItem>? RowTemplate { get; set; }
+    
+    /// <summary>
+    /// Message to display when table is empty
+    /// </summary>
+    [Parameter]
+    public string EmptyMessage { get; set; } = "No data available";
+    
+    /// <summary>
+    /// Optional callback when a row is clicked
+    /// </summary>
+    [Parameter]
+    public EventCallback<TItem> OnRowClick { get; set; }
+}
+

--- a/src/DevMetricsPro.Web/Components/Shared/MetricCard.razor
+++ b/src/DevMetricsPro.Web/Components/Shared/MetricCard.razor
@@ -1,0 +1,80 @@
+@* Professional metric card component matching design system *@
+
+<div class="metric-card">
+    <div class="metric-label">@Label</div>
+    <div class="metric-value">@Value</div>
+    
+    @if (!string.IsNullOrEmpty(Change))
+    {
+        <div class="metric-change @GetChangeClass()">
+            @if (Trend != TrendDirection.Neutral)
+            {
+                <span class="change-icon @GetTrendClass()"></span>
+            }
+            <span>@Change</span>
+        </div>
+    }
+</div>
+
+@code {
+    /// <summary>
+    /// The label/title of the metric (e.g., "Total Commits")
+    /// </summary>
+    [Parameter]
+    public string Label { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// The main value to display (e.g., "1,234")
+    /// </summary>
+    [Parameter]
+    public string Value { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// Optional change indicator (e.g., "+12.5% vs last week")
+    /// </summary>
+    [Parameter]
+    public string? Change { get; set; }
+    
+    /// <summary>
+    /// Trend direction for the metric
+    /// </summary>
+    [Parameter]
+    public TrendDirection Trend { get; set; } = TrendDirection.Neutral;
+    
+    /// <summary>
+    /// Gets CSS class for change styling based on trend
+    /// </summary>
+    private string GetChangeClass()
+    {
+        return Trend switch
+        {
+            TrendDirection.Up => "positive",
+            TrendDirection.Down => "negative",
+            _ => "neutral"
+        };
+    }
+    
+    /// <summary>
+    /// Gets CSS class for trend icon
+    /// </summary>
+    private string GetTrendClass()
+    {
+        return Trend switch
+        {
+            TrendDirection.Up => "up",
+            TrendDirection.Down => "down",
+            _ => string.Empty
+        };
+    }
+    
+    /// <summary>
+    /// Enum for trend direction
+    /// </summary>
+    public enum TrendDirection
+    {
+        Up,
+        Down,
+        Neutral
+    }
+}
+

--- a/src/DevMetricsPro.Web/Components/Shared/StatusBadge.razor
+++ b/src/DevMetricsPro.Web/Components/Shared/StatusBadge.razor
@@ -1,0 +1,46 @@
+@* Professional status badge component *@
+
+<span class="table-badge @GetBadgeClass()">
+    @Text
+</span>
+
+@code {
+    /// <summary>
+    /// The text to display in the badge
+    /// </summary>
+    [Parameter]
+    public string Text { get; set; } = string.Empty;
+    
+    /// <summary>
+    /// The status type (affects color)
+    /// </summary>
+    [Parameter]
+    public StatusType Type { get; set; } = StatusType.Info;
+    
+    /// <summary>
+    /// Gets CSS class based on status type
+    /// </summary>
+    private string GetBadgeClass()
+    {
+        return Type switch
+        {
+            StatusType.Success => "badge-success",
+            StatusType.Warning => "badge-warning",
+            StatusType.Danger => "badge-danger",
+            StatusType.Info => "badge-info",
+            _ => "badge-info"
+        };
+    }
+    
+    /// <summary>
+    /// Status type enum
+    /// </summary>
+    public enum StatusType
+    {
+        Success,
+        Warning,
+        Danger,
+        Info
+    }
+}
+

--- a/src/DevMetricsPro.Web/Components/_Imports.razor
+++ b/src/DevMetricsPro.Web/Components/_Imports.razor
@@ -8,4 +8,5 @@
 @using Microsoft.JSInterop
 @using DevMetricsPro.Web
 @using DevMetricsPro.Web.Components
+@using DevMetricsPro.Web.Components.Shared
 @using MudBlazor


### PR DESCRIPTION
- Created MetricCard component with trend indicators
- Created DataPanel component with header and actions
- Created DataTable component with generic type support
- Created StatusBadge component for status display
- Updated _Imports.razor to include Shared components

All components match the professional design system. Part 2/4 of UI redesign.

Closes #63

<!-- GitHub auto-fills description from commits below -->

## ✅ Ready to Merge?
- [x] Builds successfully
- [x] CI checks passing
- [x] Tested locally

