### PR TITLE
feat(ui): refactor pages to use professional design system (#64)

### DIFF
--- a/src/DevMetricsPro.Web/Components/Pages/Home.razor
+++ b/src/DevMetricsPro.Web/Components/Pages/Home.razor
@@ -10,197 +10,129 @@
 
 @if (!_isAuthenticated)
 {
-    <MudText Typo="Typo.h4" Class="mb-4">Welcome to DevMetrics Pro</MudText>
-    <MudText Typo="Typo.body1" Class="mb-4">
-        A real-time developer analytics platform for tracking team productivity and code quality.
-    </MudText>
-    <MudButton Href="/login" Variant="Variant.Filled" Color="Color.Primary" Size="Size.Large">
-        Get Started
-    </MudButton>
+    <div style="text-align: center; padding: 60px 20px;">
+        <h1 style="font-size: 32px; margin-bottom: 16px; color: var(--text-primary);">Welcome to DevMetrics Pro</h1>
+        <p style="font-size: 16px; margin-bottom: 24px; color: var(--text-secondary);">
+            A real-time developer analytics platform for tracking team productivity and code quality.
+        </p>
+        <a href="/login" class="panel-action" style="padding: 12px 24px; font-size: 16px; text-decoration: none; display: inline-block;">
+            Get Started
+        </a>
+    </div>
 }
 else
 {
-    <MudText Typo="Typo.h4" Class="mb-4">Dashboard</MudText>
-    
-    <MudGrid>
-        <MudItem xs="12" sm="6" md="3">
-            <MudCard Elevation="2">
-                <MudCardContent>
-                    <div style="display: flex; align-items: center; justify-content: space-between;">
-                        <div>
-                            <MudText Typo="Typo.subtitle2" Color="Color.Secondary">Total Commits</MudText>
-                            <MudText Typo="Typo.h4">@_totalCommits</MudText>
-                            <MudText Typo="Typo.body2" Color="Color.Success" Class="mt-2">
-                                <MudIcon Icon="@Icons.Material.Filled.TrendingUp" Size="Size.Small" /> +12.5% from last week
-                            </MudText>
-                        </div>
-                        <MudIcon Icon="@Icons.Material.Filled.Code" Size="Size.Large" Color="Color.Primary" />
-                    </div>
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
+    <!-- Metrics Grid -->
+    <div class="metrics-grid">
+        <MetricCard 
+            Label="Total Commits" 
+            Value="@_totalCommits.ToString("N0")" 
+            Change="+12.5% from last week"
+            Trend="MetricCard.TrendDirection.Up" />
+        
+        <MetricCard 
+            Label="Pull Requests" 
+            Value="89" 
+            Change="+8.3% from last week"
+            Trend="MetricCard.TrendDirection.Up" />
+        
+        <MetricCard 
+            Label="Active Developers" 
+            Value="24" 
+            Change="+2 this month"
+            Trend="MetricCard.TrendDirection.Up" />
+        
+        <MetricCard 
+            Label="Code Reviews" 
+            Value="156" 
+            Change="+15.2% from last week"
+            Trend="MetricCard.TrendDirection.Up" />
+    </div>
 
-        <MudItem xs="12" sm="6" md="3">
-            <MudCard Elevation="2">
-                <MudCardContent>
-                    <div style="display: flex; align-items: center; justify-content: space-between;">
-                        <div>
-                            <MudText Typo="Typo.subtitle2" Color="Color.Secondary">Pull Requests</MudText>
-                            <MudText Typo="Typo.h4">89</MudText>
-                            <MudText Typo="Typo.body2" Color="Color.Success" Class="mt-2">
-                                <MudIcon Icon="@Icons.Material.Filled.TrendingUp" Size="Size.Small" /> +8.3% from last week
-                            </MudText>
-                        </div>
-                        <MudIcon Icon="@Icons.Material.Filled.MergeType" Size="Size.Large" Color="Color.Secondary" />
-                    </div>
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
+    <!-- Panels Grid -->
+    <div class="panel-grid" style="margin-top: 24px;">
+        <DataPanel Title="Activity Overview">
+            <div style="text-align: center; padding: 60px 20px; color: var(--text-tertiary);">
+                <div style="font-size: 48px; margin-bottom: 16px;">📊</div>
+                <div style="font-size: 14px;">Chart visualization will be implemented in Sprint 3</div>
+            </div>
+        </DataPanel>
 
-        <MudItem xs="12" sm="6" md="3">
-            <MudCard Elevation="2">
-                <MudCardContent>
-                    <div style="display: flex; align-items: center; justify-content: space-between;">
-                        <div>
-                            <MudText Typo="Typo.subtitle2" Color="Color.Secondary">Active Developers</MudText>
-                            <MudText Typo="Typo.h4">24</MudText>
-                            <MudText Typo="Typo.body2" Color="Color.Success" Class="mt-2">
-                                <MudIcon Icon="@Icons.Material.Filled.TrendingUp" Size="Size.Small" /> +2 this month
-                            </MudText>
-                        </div>
-                        <MudIcon Icon="@Icons.Material.Filled.People" Size="Size.Large" Color="Color.Tertiary" />
-                    </div>
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
-
-        <MudItem xs="12" sm="6" md="3">
-            <MudCard Elevation="2">
-                <MudCardContent>
-                    <div style="display: flex; align-items: center; justify-content: space-between;">
-                        <div>
-                            <MudText Typo="Typo.subtitle2" Color="Color.Secondary">Code Reviews</MudText>
-                            <MudText Typo="Typo.h4">156</MudText>
-                            <MudText Typo="Typo.body2" Color="Color.Success" Class="mt-2">
-                                <MudIcon Icon="@Icons.Material.Filled.TrendingUp" Size="Size.Small" /> +15.2% from last week
-                            </MudText>
-                        </div>
-                        <MudIcon Icon="@Icons.Material.Filled.RateReview" Size="Size.Large" Color="Color.Info" />
-                    </div>
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
-    </MudGrid>
-
-    <MudGrid Class="mt-4">
-        <MudItem xs="12" md="8">
-            <MudCard Elevation="2">
-                <MudCardHeader>
-                    <CardHeaderContent>
-                        <MudText Typo="Typo.h6">Activity Overview</MudText>
-                    </CardHeaderContent>
-                </MudCardHeader>
-                <MudCardContent>
-                    <MudText Typo="Typo.body2" Color="Color.Secondary" Align="Align.Center" Class="py-8">
-                        <MudIcon Icon="@Icons.Material.Filled.ShowChart" Size="Size.Large" Color="Color.Secondary" Class="mb-2" />
-                        <br />
-                        Chart visualization will be implemented in Sprint 3
-                    </MudText>
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
-
-        <MudItem xs="12" md="4">
-            <MudCard Elevation="2">
-                <MudCardHeader>
-                    <CardHeaderContent>
-                        <MudText Typo="Typo.h6">Recent Activity</MudText>
-                    </CardHeaderContent>
-                </MudCardHeader>
-                <MudCardContent>
-                    <MudList T="string" Dense="true">
-                        @if (_recentCommits.Any())
-                        {
-                            @foreach (var commit in _recentCommits)
-                            {
-                                <MudListItem T="string" Icon="@Icons.Material.Filled.Code">
-                                    <MudText Typo="Typo.body2">
-                                        @(commit.Message.Length > 50 ? commit.Message.Substring(0, 50) + "..." : commit.Message)
-                                    </MudText>
-                                    <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                        @commit.AuthorName in @commit.RepositoryName • @GetRelativeTime(commit.CommittedAt)
-                                    </MudText>
-                                </MudListItem>
-                            }
-                        }
-                        else
-                        {
-                            <MudListItem T="string" Icon="@Icons.Material.Filled.Info">
-                                <MudText Typo="Typo.body2" Color="Color.Secondary">No commits yet</MudText>
-                                <MudText Typo="Typo.caption" Color="Color.Secondary">Sync your repositories to see commits</MudText>
-                            </MudListItem>
-                        }
-                    </MudList>
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
-    </MudGrid>
+        <DataPanel Title="Recent Activity">
+            @if (_recentCommits.Any())
+            {
+                <DataTable TItem="RecentCommitDto" Items="@_recentCommits">
+                    <TableHeader>
+                        <th>Commit</th>
+                        <th class="text-right">Time</th>
+                    </TableHeader>
+                    <RowTemplate>
+                        <td>
+                            <div style="font-size: 13px; color: var(--text-primary); margin-bottom: 2px;">
+                                @(context.Message.Length > 40 ? context.Message.Substring(0, 40) + "..." : context.Message)
+                            </div>
+                            <div class="text-small text-muted">
+                                @context.AuthorName in @context.RepositoryName
+                            </div>
+                        </td>
+                        <td class="text-right text-small text-muted">
+                            @GetRelativeTime(context.CommittedAt)
+                        </td>
+                    </RowTemplate>
+                </DataTable>
+            }
+            else
+            {
+                <div style="text-align: center; padding: 40px 20px; color: var(--text-tertiary);">
+                    <div style="font-size: 14px; margin-bottom: 4px;">No commits yet</div>
+                    <div style="font-size: 12px;">Sync your repositories to see commits</div>
+                </div>
+            }
+        </DataPanel>
+    </div>
 }
 
 @if (_isAuthenticated)
 {
-    <MudGrid Class="mt-4">
-        <MudItem xs="12" md="6">
-            <MudCard Elevation="2">
-                <MudCardHeader>
-                    <CardHeaderContent>
-                        <MudText Typo="Typo.h6">
-                            <MudIcon Icon="@Icons.Custom.Brands.GitHub" Class="mr-2" />
-                            GitHub Integration
-                        </MudText>
-                    </CardHeaderContent>
-                </MudCardHeader>
-                <MudCardContent>
-                    @if (!isGitHubConnected)
+    <div style="margin-top: 24px; max-width: 600px;">
+        <DataPanel Title="GitHub Integration">
+            @if (!isGitHubConnected)
+            {
+                <p style="font-size: 14px; color: var(--text-secondary); margin-bottom: 16px;">
+                    Connect your GitHub account to sync repositories and track metrics.
+                </p>
+                <button class="panel-action" @onclick="ConnectGitHub" disabled="@isConnectingGitHub" 
+                        style="padding: 8px 16px; background: var(--text-primary); color: white; cursor: @(isConnectingGitHub ? "not-allowed" : "pointer");">
+                    @if (isConnectingGitHub)
                     {
-                        <MudText Typo="Typo.body2" Class="mb-3">
-                            Connect your GitHub account to sync repositories and track metrics.
-                        </MudText>
-                        <MudButton 
-                            Variant="Variant.Filled" 
-                            Color="Color.Dark" 
-                            StartIcon="@Icons.Custom.Brands.GitHub"
-                            OnClick="ConnectGitHub"
-                            Disabled="isConnectingGitHub">
-                            @if (isConnectingGitHub)
-                            {
-                                <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
-                                <span>Connecting...</span>
-                            }
-                            else
-                            {
-                                <span>Connect GitHub</span>
-                            }
-                        </MudButton>
+                        <span>Connecting...</span>
                     }
                     else
                     {
-                        <MudAlert Severity="Severity.Success" Class="mb-3">
-                            ✓ Connected as <strong>@@@githubUsername</strong>
-                        </MudAlert>
-                        <MudText Typo="Typo.body2" Color="Color.Secondary">
-                            Your GitHub account is linked and ready to sync.
-                        </MudText>
+                        <span>Connect GitHub</span>
                     }
-                    
-                    @if (!string.IsNullOrEmpty(githubConnectedMessage))
-                    {
-                        <MudAlert Severity="Severity.Info" Class="mt-3">@githubConnectedMessage</MudAlert>
-                    }
-                </MudCardContent>
-            </MudCard>
-        </MudItem>
-    </MudGrid>
+                </button>
+            }
+            else
+            {
+                <div style="padding: 12px; background: rgba(40, 167, 69, 0.1); border-radius: 4px; margin-bottom: 16px;">
+                    <div style="color: var(--success); font-size: 14px;">
+                        ✓ Connected as <strong>@@@githubUsername</strong>
+                    </div>
+                </div>
+                <p style="font-size: 14px; color: var(--text-secondary);">
+                    Your GitHub account is linked and ready to sync.
+                </p>
+            }
+            
+            @if (!string.IsNullOrEmpty(githubConnectedMessage))
+            {
+                <div style="padding: 12px; background: rgba(3, 102, 214, 0.1); border-radius: 4px; margin-top: 16px;">
+                    <div style="color: var(--info); font-size: 14px;">@githubConnectedMessage</div>
+                </div>
+            }
+        </DataPanel>
+    </div>
 }
 
 @code {

--- a/src/DevMetricsPro.Web/Components/Pages/Repositories.razor
+++ b/src/DevMetricsPro.Web/Components/Pages/Repositories.razor
@@ -9,169 +9,152 @@
 
 <PageTitle>Repositories - DevMetrics Pro</PageTitle>
 
-<MudText Typo="Typo.h4" Class="mb-4">My Repositories</MudText>
+<h1 style="font-size: 24px; margin-bottom: 24px; color: var(--text-primary); font-weight: 600;">My Repositories</h1>
 
 @if (!_isAuthenticated)
 {
-    <MudAlert Severity="Severity.Warning">
-        Please <MudLink Href="/login">login</MudLink> to view your repositories.
-    </MudAlert>
+    <div style="padding: 16px; background: rgba(255, 165, 0, 0.1); border-left: 3px solid var(--warning); border-radius: var(--border-radius);">
+        <div style="font-size: 14px; color: var(--text-primary);">
+            Please <a href="/login" style="color: var(--info); text-decoration: underline;">login</a> to view your repositories.
+        </div>
+    </div>
 }
 else if (!_isGitHubConnected)
 {
-    <MudAlert Severity="Severity.Info">
-        <MudText>You haven't connected your GitHub account yet.</MudText>
-        <MudButton Href="/" Variant="Variant.Text" Color="Color.Primary" Class="mt-2">
+    <div style="padding: 16px; background: rgba(3, 102, 214, 0.1); border-left: 3px solid var(--info); border-radius: var(--border-radius);">
+        <div style="font-size: 14px; color: var(--text-primary); margin-bottom: 12px;">
+            You haven't connected your GitHub account yet.
+        </div>
+        <a href="/" class="panel-action" style="text-decoration: none; display: inline-block;">
             Go to Dashboard to Connect GitHub
-        </MudButton>
-    </MudAlert>
+        </a>
+    </div>
 }
 else if (_isLoading)
 {
     <div style="display: flex; justify-content: center; align-items: center; min-height: 400px;">
-        <MudProgressCircular Size="Size.Large" Indeterminate="true" />
+        <div style="font-size: 14px; color: var(--text-tertiary);">Loading repositories...</div>
     </div>
 }
 else if (!string.IsNullOrEmpty(_errorMessage))
 {
-    <MudAlert Severity="Severity.Error" Class="mb-4">
-        @_errorMessage
-        <MudButton OnClick="LoadRepositoriesAsync" Variant="Variant.Text" Color="Color.Error" Class="mt-2">
+    <div style="padding: 16px; background: rgba(215, 58, 73, 0.1); border-left: 3px solid var(--danger); border-radius: var(--border-radius); margin-bottom: 24px;">
+        <div style="font-size: 14px; color: var(--text-primary); margin-bottom: 12px;">
+            @_errorMessage
+        </div>
+        <button class="panel-action" @onclick="LoadRepositoriesAsync">
             Retry
-        </MudButton>
-    </MudAlert>
+        </button>
+    </div>
 }
 else if (_repositories.Count == 0)
 {
-    <MudCard Elevation="2">
-        <MudCardContent>
-            <div style="text-align: center; padding: 60px 20px;">
-                <MudIcon Icon="@Icons.Material.Filled.FolderOpen" Size="Size.Large" Color="Color.Secondary" Class="mb-4" />
-                <MudText Typo="Typo.h6" Class="mb-2">No Repositories Found</MudText>
-                <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-4">
-                    Click "Sync Now" to fetch your repositories from GitHub.
-                </MudText>
-                <MudButton 
-                    Variant="Variant.Filled" 
-                    Color="Color.Primary" 
-                    StartIcon="@Icons.Material.Filled.Sync"
-                    OnClick="SyncRepositoriesAsync"
-                    Disabled="_isSyncing">
-                    Sync Now
-                </MudButton>
+    <DataPanel Title="No Repositories">
+        <div style="text-align: center; padding: 60px 20px;">
+            <div style="font-size: 48px; margin-bottom: 16px;">📁</div>
+            <div style="font-size: 16px; margin-bottom: 8px; color: var(--text-primary);">No Repositories Found</div>
+            <div style="font-size: 14px; color: var(--text-secondary); margin-bottom: 24px;">
+                Click "Sync Now" to fetch your repositories from GitHub.
             </div>
-        </MudCardContent>
-    </MudCard>
+            <button class="panel-action" @onclick="SyncRepositoriesAsync" disabled="@_isSyncing" 
+                    style="padding: 8px 16px; background: var(--info); color: white;">
+                @if (_isSyncing)
+                {
+                    <span>Syncing...</span>
+                }
+                else
+                {
+                    <span>Sync Now</span>
+                }
+            </button>
+        </div>
+    </DataPanel>
 }
 else
 {
     <!-- Header with Sync Button -->
-    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;">
-        <MudText Typo="Typo.body1" Color="Color.Secondary">
+    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px;">
+        <div style="font-size: 14px; color: var(--text-secondary);">
             @_repositories.Count repositories
             @if (_lastSyncTime.HasValue)
             {
                 <span> • Last synced @GetRelativeTime(_lastSyncTime.Value)</span>
             }
-        </MudText>
-        <MudButton 
-            Variant="Variant.Filled" 
-            Color="Color.Primary" 
-            StartIcon="@Icons.Material.Filled.Sync"
-            OnClick="SyncRepositoriesAsync"
-            Disabled="_isSyncing">
+        </div>
+        <button class="panel-action" @onclick="SyncRepositoriesAsync" disabled="@_isSyncing" 
+                style="padding: 8px 16px; background: var(--info); color: white;">
             @if (_isSyncing)
             {
-                <MudProgressCircular Size="Size.Small" Indeterminate="true" Class="mr-2" />
                 <span>Syncing...</span>
             }
             else
             {
-                <span>Sync Now</span>
+                <span>⟳ Sync Now</span>
             }
-        </MudButton>
+        </button>
     </div>
 
     <!-- Repository Grid -->
-    <MudGrid>
+    <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: 16px;">
         @foreach (var repo in _repositories)
         {
-            <MudItem xs="12" sm="6" md="4">
-                <MudCard Elevation="2" Style="height: 100%;">
-                    <MudCardContent>
-                        <!-- Repository Name -->
-                        <MudLink Href="@repo.HtmlUrl" Target="_blank" Underline="Underline.Hover">
-                            <MudText Typo="Typo.h6" Style="margin-bottom: 8px;">
-                                @repo.Name
-                            </MudText>
-                        </MudLink>
+            <div class="panel" style="height: 100%; display: flex; flex-direction: column;">
+                <div style="padding: 16px; flex: 1;">
+                    <!-- Repository Name -->
+                    <a href="@repo.HtmlUrl" target="_blank" style="color: var(--info); text-decoration: none; font-size: 16px; font-weight: 600; display: block; margin-bottom: 8px;">
+                        @repo.Name
+                    </a>
 
-                        <!-- Description -->
-                        @if (!string.IsNullOrEmpty(repo.Description))
-                        {
-                            <MudText Typo="Typo.body2" Color="Color.Secondary" Style="margin-bottom: 12px; min-height: 40px;">
-                                @(repo.Description.Length > 100 ? repo.Description.Substring(0, 100) + "..." : repo.Description)
-                            </MudText>
-                        }
-                        else
-                        {
-                            <MudText Typo="Typo.body2" Color="Color.Secondary" Style="margin-bottom: 12px; min-height: 40px; font-style: italic;">
-                                No description provided
-                            </MudText>
-                        }
-
-                        <!-- Language Badge -->
-                        @if (!string.IsNullOrEmpty(repo.Language))
-                        {
-                            <MudChip T="string" Size="Size.Small" Color="Color.Info" Style="margin-bottom: 12px;">
-                                @repo.Language
-                            </MudChip>
-                        }
-
-                        <!-- Stats -->
-                        <div style="display: flex; gap: 16px; margin-top: 12px;">
-                            <div style="display: flex; align-items: center; gap: 4px;">
-                                <MudIcon Icon="@Icons.Material.Filled.Star" Size="Size.Small" Color="Color.Warning" />
-                                <MudText Typo="Typo.caption">@repo.StargazersCount</MudText>
-                            </div>
-                            <div style="display: flex; align-items: center; gap: 4px;">
-                                <MudIcon Icon="@Icons.Material.Filled.CallSplit" Size="Size.Small" Color="Color.Info" />
-                                <MudText Typo="Typo.caption">@repo.ForksCount</MudText>
-                            </div>
-                            <div style="display: flex; align-items: center; gap: 4px;">
-                                <MudIcon Icon="@Icons.Material.Filled.BugReport" Size="Size.Small" Color="Color.Error" />
-                                <MudText Typo="Typo.caption">@repo.OpenIssuesCount</MudText>
-                            </div>
+                    <!-- Description -->
+                    @if (!string.IsNullOrEmpty(repo.Description))
+                    {
+                        <div style="font-size: 13px; color: var(--text-secondary); margin-bottom: 12px; min-height: 40px;">
+                            @(repo.Description.Length > 100 ? repo.Description.Substring(0, 100) + "..." : repo.Description)
                         </div>
-
-                        <!-- Badges -->
-                        <div style="margin-top: 12px; display: flex; gap: 8px;">
-                            @if (repo.IsPrivate)
-                            {
-                                <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Warning">
-                                    Private
-                                </MudChip>
-                            }
-                            @if (repo.IsFork)
-                            {
-                                <MudChip T="string" Size="Size.Small" Variant="Variant.Outlined" Color="Color.Info">
-                                    Fork
-                                </MudChip>
-                            }
+                    }
+                    else
+                    {
+                        <div style="font-size: 13px; color: var(--text-tertiary); margin-bottom: 12px; min-height: 40px; font-style: italic;">
+                            No description provided
                         </div>
+                    }
 
-                        <!-- Last Updated -->
-                        @if (repo.PushedAt.HasValue)
+                    <!-- Language Badge -->
+                    @if (!string.IsNullOrEmpty(repo.Language))
+                    {
+                        <StatusBadge Text="@repo.Language" Type="StatusBadge.StatusType.Info" />
+                    }
+
+                    <!-- Stats -->
+                    <div style="display: flex; gap: 16px; margin-top: 12px; font-size: 12px; color: var(--text-tertiary);">
+                        <div>⭐ @repo.StargazersCount</div>
+                        <div>🔱 @repo.ForksCount</div>
+                        <div>🐛 @repo.OpenIssuesCount</div>
+                    </div>
+
+                    <!-- Badges -->
+                    <div style="margin-top: 12px; display: flex; gap: 8px;">
+                        @if (repo.IsPrivate)
                         {
-                            <MudText Typo="Typo.caption" Color="Color.Secondary" Style="margin-top: 12px;">
-                                Updated @GetRelativeTime(repo.PushedAt.Value)
-                            </MudText>
+                            <StatusBadge Text="Private" Type="StatusBadge.StatusType.Warning" />
                         }
-                    </MudCardContent>
-                </MudCard>
-            </MudItem>
+                        @if (repo.IsFork)
+                        {
+                            <StatusBadge Text="Fork" Type="StatusBadge.StatusType.Info" />
+                        }
+                    </div>
+
+                    <!-- Last Updated -->
+                    @if (repo.PushedAt.HasValue)
+                    {
+                        <div class="text-small text-muted" style="margin-top: 12px;">
+                            Updated @GetRelativeTime(repo.PushedAt.Value)
+                        </div>
+                    }
+                </div>
+            </div>
         }
-    </MudGrid>
+    </div>
 }
 
 @code {


### PR DESCRIPTION
- Refactored Home.razor to use MetricCard, DataPanel, and DataTable
- Refactored Repositories.razor with professional styling
- Replaced all MudBlazor cards and alerts with design system components
- Improved visual hierarchy and consistency
- Used CSS variables for colors and spacing

All pages now match the professional NASA/CERN-inspired design. Part 3/4 of UI redesign.

Closes #64

<!-- GitHub auto-fills description from commits below -->

## ✅ Ready to Merge?
- [x] Builds successfully
- [x] CI checks passing
- [x] Tested locally

