### PR TITLE
feat(github): implement pull request service with Octokit

### DIFF
--- a/src/DevMetricsPro.Infrastructure/Services/GitHubPullRequestService.cs
+++ b/src/DevMetricsPro.Infrastructure/Services/GitHubPullRequestService.cs
@@ -1,0 +1,124 @@
+using DevMetricsPro.Application.DTOs.GitHub;
+using DevMetricsPro.Application.Interfaces;
+using Microsoft.Extensions.Logging;
+using Octokit;
+
+namespace DevMetricsPro.Infrastructure.Services;
+
+/// <summary>
+/// Service for fetching pull request data from GitHub API using Octokit
+/// </summary>
+public class GitHubPullRequestService : IGitHubPullRequestService
+{
+    private readonly ILogger<GitHubPullRequestService> _logger;
+
+    public GitHubPullRequestService(ILogger<GitHubPullRequestService> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Fetches pull requests for a specific GitHub repository
+    /// </summary>
+    public async Task<IEnumerable<GitHubPullRequestDto>> GetRepositoryPullRequestsAsync(
+        string owner,
+        string repositoryName,
+        string accessToken,
+        DateTime? since = null,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            _logger.LogInformation(
+                "Fetching pull requests for {Owner}/{Repository} from GitHub API",
+                owner, repositoryName);
+
+            // Create GitHub client with OAuth token
+            var client = new GitHubClient(new ProductHeaderValue("DevMetricsPro"))
+            {
+                Credentials = new Credentials(accessToken)
+            };
+
+            // Create PR request with filters
+            var request = new PullRequestRequest
+            {
+                State = ItemStateFilter.All, // Fetch both open and closed PRs
+                SortProperty = PullRequestSort.Updated,
+                SortDirection = SortDirection.Descending
+            };
+
+            // Fetch all pull requests
+            var pullRequests = await client.PullRequest.GetAllForRepository(owner, repositoryName, request);
+
+            _logger.LogInformation(
+                "Successfully fetched {Count} pull requests for {Owner}/{Repository}",
+                pullRequests.Count, owner, repositoryName);
+
+            // Filter by date if 'since' is provided (for incremental sync)
+            var filteredPRs = since.HasValue
+                ? pullRequests.Where(pr => pr.UpdatedAt >= since.Value)
+                : pullRequests;
+
+            // Map Octokit PullRequest objects to our DTO
+            var result = filteredPRs.Select(pr => new GitHubPullRequestDto
+            {
+                Number = pr.Number,
+                Title = pr.Title,
+                State = pr.State.StringValue,
+                Body = pr.Body,
+                HtmlUrl = pr.HtmlUrl,
+                AuthorLogin = pr.User.Login,
+                AuthorName = pr.User.Name,
+                CreatedAt = pr.CreatedAt.UtcDateTime,
+                UpdatedAt = pr.UpdatedAt.UtcDateTime,
+                ClosedAt = pr.ClosedAt?.UtcDateTime,
+                MergedAt = pr.MergedAt?.UtcDateTime,
+                IsMerged = pr.Merged,
+                IsDraft = pr.Draft,
+                Additions = pr.Additions,
+                Deletions = pr.Deletions,
+                ChangedFiles = pr.ChangedFiles,
+                RepositoryName = repositoryName
+            }).ToList();
+
+            if (since.HasValue)
+            {
+                _logger.LogInformation(
+                    "Filtered to {Count} pull requests updated since {Since}",
+                    result.Count, since.Value);
+            }
+
+            return result;
+        }
+        catch (NotFoundException ex)
+        {
+            _logger.LogError(ex,
+                "Repository {Owner}/{Repository} not found on GitHub",
+                owner, repositoryName);
+            throw new InvalidOperationException(
+                $"Repository {owner}/{repositoryName} not found.", ex);
+        }
+        catch (AuthorizationException ex)
+        {
+            _logger.LogError(ex,
+                "GitHub authorization failed for {Owner}/{Repository}. Token may be invalid or expired",
+                owner, repositoryName);
+            throw new UnauthorizedAccessException(
+                "GitHub authorization failed. Please reconnect your GitHub account.", ex);
+        }
+        catch (RateLimitExceededException ex)
+        {
+            _logger.LogError(ex, "GitHub API rate limit exceeded");
+            throw new InvalidOperationException(
+                "GitHub API rate limit exceeded. Please try again later.", ex);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Error fetching pull requests for {Owner}/{Repository}",
+                owner, repositoryName);
+            throw;
+        }
+    }
+}
+

--- a/src/DevMetricsPro.Web/Program.cs
+++ b/src/DevMetricsPro.Web/Program.cs
@@ -84,6 +84,7 @@ try
     builder.Services.AddScoped<IGitHubOAuthService, GitHubOAuthService>();
     builder.Services.AddScoped<IGitHubRepositoryService, GitHubRepositoryService>();
     builder.Services.AddScoped<IGitHubCommitsService, GitHubCommitsService>();
+    builder.Services.AddScoped<IGitHubPullRequestService, GitHubPullRequestService>();
 
     // Background Jobs
     builder.Services.AddScoped<DevMetricsPro.Web.Jobs.SyncGitHubDataJob>();


### PR DESCRIPTION
- Create GitHubPullRequestService in Infrastructure layer
- Fetch PRs using Octokit client (ItemStateFilter.All)
- Map Octokit PullRequest to GitHubPullRequestDto
- Support incremental sync with since parameter
- Handle all PR states (open, closed, merged, draft)
- Add error handling (404, auth, rate limits)
- Register service in DI container

Part of Phase 2.6.2
Closes #75

<!-- GitHub auto-fills description from commits below -->

## ✅ Ready to Merge?
- [x] Builds successfully
- [x] CI checks passing
- [x] Tested locally

