### PR TITLE
feat: add Redis caching for GitHub data

### DIFF
--- a/src/DevMetricsPro.Application/Caching/CacheDurations.cs
+++ b/src/DevMetricsPro.Application/Caching/CacheDurations.cs
@@ -1,0 +1,12 @@
+namespace DevMetricsPro.Application.Caching;
+
+/// <summary>
+/// TTL definitions for frequently cached data.
+/// </summary>
+public static class CacheDurations
+{
+    public static readonly TimeSpan GitHubConnectionStatus = TimeSpan.FromMinutes(1);
+    public static readonly TimeSpan GitHubRepositories = TimeSpan.FromMinutes(5);
+    public static readonly TimeSpan DashboardMetrics = TimeSpan.FromMinutes(10);
+}
+

--- a/src/DevMetricsPro.Application/Caching/CacheKeys.cs
+++ b/src/DevMetricsPro.Application/Caching/CacheKeys.cs
@@ -1,0 +1,19 @@
+namespace DevMetricsPro.Application.Caching;
+
+/// <summary>
+/// Central place for cache key naming conventions to avoid typos.
+/// </summary>
+public static class CacheKeys
+{
+    private const string Prefix = "devmetrics";
+
+    public static string GitHubConnectionStatus(Guid userId) =>
+        $"{Prefix}:github:status:{userId}";
+
+    public static string GitHubRepositories(Guid userId) =>
+        $"{Prefix}:github:repos:{userId}";
+
+    public static string GitHubRecentCommits(Guid userId, int limit) =>
+        $"{Prefix}:github:commits:{userId}:limit:{limit}";
+}
+

--- a/src/DevMetricsPro.Application/Interfaces/ICacheService.cs
+++ b/src/DevMetricsPro.Application/Interfaces/ICacheService.cs
@@ -1,0 +1,36 @@
+namespace DevMetricsPro.Application.Interfaces;
+
+/// <summary>
+/// Simple abstraction over the distributed cache implementation.
+/// Keeps caching logic inside the Infrastructure layer while allowing
+/// Application/Web layers to depend on an interface.
+/// </summary>
+public interface ICacheService
+{
+    /// <summary>
+    /// Attempts to retrieve a cached value.
+    /// </summary>
+    /// <typeparam name="T">Type of the cached payload.</typeparam>
+    /// <param name="key">Cache key.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The cached value or null when missing.</returns>
+    Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Stores a value in cache for the specified duration.
+    /// </summary>
+    /// <typeparam name="T">Type of the payload.</typeparam>
+    /// <param name="key">Cache key.</param>
+    /// <param name="value">Payload to cache.</param>
+    /// <param name="ttl">Expiration duration.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task SetAsync<T>(string key, T value, TimeSpan ttl, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Removes a cache entry if it exists.
+    /// </summary>
+    /// <param name="key">Cache key.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task RemoveAsync(string key, CancellationToken cancellationToken = default);
+}
+

--- a/src/DevMetricsPro.Infrastructure/Services/RedisCacheService.cs
+++ b/src/DevMetricsPro.Infrastructure/Services/RedisCacheService.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using DevMetricsPro.Application.Interfaces;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+
+namespace DevMetricsPro.Infrastructure.Services;
+
+/// <summary>
+/// Default implementation of <see cref="ICacheService"/> backed by <see cref="IDistributedCache"/>.
+/// </summary>
+public class RedisCacheService : ICacheService
+{
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private readonly IDistributedCache _cache;
+    private readonly ILogger<RedisCacheService> _logger;
+
+    public RedisCacheService(IDistributedCache cache, ILogger<RedisCacheService> logger)
+    {
+        _cache = cache;
+        _logger = logger;
+    }
+
+    public async Task<T?> GetAsync<T>(string key, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var cached = await _cache.GetStringAsync(key, cancellationToken);
+            return string.IsNullOrWhiteSpace(cached)
+                ? default
+                : JsonSerializer.Deserialize<T>(cached, SerializerOptions);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to read cache key {CacheKey}", key);
+            return default;
+        }
+    }
+
+    public async Task SetAsync<T>(string key, T value, TimeSpan ttl, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var serialized = JsonSerializer.Serialize(value, SerializerOptions);
+            var options = new DistributedCacheEntryOptions
+            {
+                AbsoluteExpirationRelativeToNow = ttl
+            };
+
+            await _cache.SetStringAsync(key, serialized, options, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to write cache key {CacheKey}", key);
+        }
+    }
+
+    public async Task RemoveAsync(string key, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await _cache.RemoveAsync(key, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to remove cache key {CacheKey}", key);
+        }
+    }
+}
+

--- a/src/DevMetricsPro.Web/Components/Pages/Repositories.razor
+++ b/src/DevMetricsPro.Web/Components/Pages/Repositories.razor
@@ -258,18 +258,18 @@ else
                 return;
             }
 
-            var request = new HttpRequestMessage(HttpMethod.Post, "/api/github/sync-repositories");
+            var request = new HttpRequestMessage(HttpMethod.Get, "/api/github/repositories");
             request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             
             var response = await Http.SendAsync(request);
             
             if (response.IsSuccessStatusCode)
             {
-                var result = await response.Content.ReadFromJsonAsync<SyncRepositoriesResponse>();
+                var result = await response.Content.ReadFromJsonAsync<GetRepositoriesResponse>();
                 if (result?.Success == true && result.Repositories != null)
                 {
                     _repositories = result.Repositories.OrderByDescending(r => r.StargazersCount).ToList();
-                    _lastSyncTime = DateTime.UtcNow;
+                    _lastSyncTime = result.LastSyncedAt;
                     Logger.LogInformation("Loaded {Count} repositories", _repositories.Count);
                 }
             }
@@ -301,15 +301,28 @@ else
         
         try
         {
-            await LoadRepositoriesAsync();
-            
-            if (string.IsNullOrEmpty(_errorMessage))
+            var token = await AuthState.GetTokenAsync();
+            if (string.IsNullOrEmpty(token))
             {
-                Snackbar.Add($"Successfully synced {_repositories.Count} repositories!", Severity.Success);
+                Snackbar.Add("Authentication required", Severity.Warning);
+                return;
+            }
+
+            var request = new HttpRequestMessage(HttpMethod.Post, "/api/github/sync-repositories");
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+
+            var response = await Http.SendAsync(request);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var result = await response.Content.ReadFromJsonAsync<SyncRepositoriesResponse>();
+                Snackbar.Add($"Successfully synced {result?.Count ?? 0} repositories!", Severity.Success);
+                await LoadRepositoriesAsync();
             }
             else
             {
-                Snackbar.Add(_errorMessage, Severity.Error);
+                var message = await ResolveProblemDetailsMessageAsync(response, "Failed to sync repositories.");
+                Snackbar.Add(message, Severity.Error);
             }
         }
         finally
@@ -388,6 +401,13 @@ else
         public bool Success { get; set; }
         public int Count { get; set; }
         public List<GitHubRepositoryDto>? Repositories { get; set; }
+    }
+
+    private class GetRepositoriesResponse
+    {
+        public bool Success { get; set; }
+        public List<GitHubRepositoryDto>? Repositories { get; set; }
+        public DateTime? LastSyncedAt { get; set; }
     }
 
     private class GitHubStatusResponse

--- a/src/DevMetricsPro.Web/DevMetricsPro.Web.csproj
+++ b/src/DevMetricsPro.Web/DevMetricsPro.Web.csproj
@@ -18,6 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.0" />
     <PackageReference Include="MudBlazor" Version="8.13.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />

--- a/src/DevMetricsPro.Web/appsettings.json
+++ b/src/DevMetricsPro.Web/appsettings.json
@@ -1,6 +1,7 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5432;Database=devmetrics_dev;Username=devmetrics;Password=DevMetrics2024!"
+    "DefaultConnection": "Host=localhost;Port=5432;Database=devmetrics_dev;Username=devmetrics;Password=DevMetrics2024!",
+    "Redis": "REPLACE_WITH_USER_SECRETS"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
- register distributed cache plus shared cache service abstraction\n- cache repo lists, connection status and dashboard commits with sensible TTLs\n- invalidate caches after sync jobs/callbacks and expose GET /api/github/repositories for UI\n- update Repositories page to leverage cached API and keep manual sync flow
 Closing #94 
<!-- GitHub auto-fills description from commits below -->

## ✅ Ready to Merge?
- [x] Builds successfully
- [x] CI checks passing
- [x] Tested locally

