### PR TITLE
feat(charts): add GitHub-style contribution heatmap #118

### DIFF
--- a/src/DevMetricsPro.Application/DTOs/Charts/ContributionHeatmapDto.cs
+++ b/src/DevMetricsPro.Application/DTOs/Charts/ContributionHeatmapDto.cs
@@ -1,0 +1,110 @@
+namespace DevMetricsPro.Application.DTOs.Charts;
+
+/// <summary>
+/// DTO for GitHub-style contribution heatmap data.
+/// </summary>
+public record ContributionHeatmapDto
+{
+    /// <summary>
+    /// List of daily contributions for the heatmap.
+    /// </summary>
+    public required List<DayContribution> Days { get; init; }
+    
+    /// <summary>
+    /// Maximum contributions on a single day (for scaling colors).
+    /// </summary>
+    public int MaxContributions { get; init; }
+    
+    /// <summary>
+    /// Total contributions in the period.
+    /// </summary>
+    public int TotalContributions { get; init; }
+    
+    /// <summary>
+    /// Number of weeks displayed.
+    /// </summary>
+    public int NumberOfWeeks { get; init; }
+    
+    /// <summary>
+    /// Start date of the heatmap.
+    /// </summary>
+    public DateTime StartDate { get; init; }
+    
+    /// <summary>
+    /// End date of the heatmap.
+    /// </summary>
+    public DateTime EndDate { get; init; }
+    
+    /// <summary>
+    /// Creates an empty heatmap for the specified period.
+    /// </summary>
+    public static ContributionHeatmapDto CreateEmpty(int numberOfWeeks)
+    {
+        var endDate = DateTime.UtcNow.Date;
+        var startDate = endDate.AddDays(-(numberOfWeeks * 7) + 1);
+        
+        var days = new List<DayContribution>();
+        for (var date = startDate; date <= endDate; date = date.AddDays(1))
+        {
+            days.Add(new DayContribution
+            {
+                Date = date,
+                Count = 0,
+                Level = ContributionLevel.None
+            });
+        }
+        
+        return new ContributionHeatmapDto
+        {
+            Days = days,
+            MaxContributions = 0,
+            TotalContributions = 0,
+            NumberOfWeeks = numberOfWeeks,
+            StartDate = startDate,
+            EndDate = endDate
+        };
+    }
+}
+
+/// <summary>
+/// Represents a single day's contribution data.
+/// </summary>
+public record DayContribution
+{
+    /// <summary>
+    /// The date of this contribution.
+    /// </summary>
+    public DateTime Date { get; init; }
+    
+    /// <summary>
+    /// Number of contributions (commits) on this day.
+    /// </summary>
+    public int Count { get; init; }
+    
+    /// <summary>
+    /// Contribution level for color coding.
+    /// </summary>
+    public ContributionLevel Level { get; init; }
+}
+
+/// <summary>
+/// Contribution intensity levels for heatmap coloring.
+/// </summary>
+public enum ContributionLevel
+{
+    /// <summary>No contributions (0)</summary>
+    None = 0,
+    
+    /// <summary>Low activity (1-2 commits)</summary>
+    Low = 1,
+    
+    /// <summary>Medium activity (3-5 commits)</summary>
+    Medium = 2,
+    
+    /// <summary>High activity (6-9 commits)</summary>
+    High = 3,
+    
+    /// <summary>Maximum activity (10+ commits)</summary>
+    Max = 4
+}
+

--- a/src/DevMetricsPro.Application/Interfaces/IChartDataService.cs
+++ b/src/DevMetricsPro.Application/Interfaces/IChartDataService.cs
@@ -32,4 +32,16 @@ public interface IChartDataService
         int days = 30,
         Guid? developerId = null,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get contribution heatmap data for GitHub-style visualization
+    /// </summary>
+    /// <param name="numberOfWeeks">Number of weeks to display (default: 52)</param>
+    /// <param name="developerId">Optional developer ID to filter by</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Heatmap data with daily contribution counts and levels</returns>
+    Task<ContributionHeatmapDto> GetContributionHeatmapAsync(
+        int numberOfWeeks = 52,
+        Guid? developerId = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/DevMetricsPro.Web/Components/Pages/Home.razor
+++ b/src/DevMetricsPro.Web/Components/Pages/Home.razor
@@ -212,6 +212,43 @@ else
         }
     </MudPaper>
 
+    <!-- Contribution Heatmap - Phase 3.4 -->
+    <MudPaper Class="pa-4 mt-4">
+        <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
+            <MudText Typo="Typo.h5">🗓️ Contribution Activity</MudText>
+            
+            <!-- Week Range Selector -->
+            <div style="display: flex; gap: 8px;">
+                <MudButton 
+                    Size="Size.Small" 
+                    Variant="@(_selectedWeeks == 13 ? Variant.Filled : Variant.Outlined)"
+                    Color="Color.Primary"
+                    OnClick="() => LoadHeatmapAsync(13)">
+                    3 Months
+                </MudButton>
+                <MudButton 
+                    Size="Size.Small" 
+                    Variant="@(_selectedWeeks == 26 ? Variant.Filled : Variant.Outlined)"
+                    Color="Color.Primary"
+                    OnClick="() => LoadHeatmapAsync(26)">
+                    6 Months
+                </MudButton>
+                <MudButton 
+                    Size="Size.Small" 
+                    Variant="@(_selectedWeeks == 52 ? Variant.Filled : Variant.Outlined)"
+                    Color="Color.Primary"
+                    OnClick="() => LoadHeatmapAsync(52)">
+                    1 Year
+                </MudButton>
+            </div>
+        </div>
+
+        <ContributionHeatmap 
+            Data="@_heatmapData"
+            Title="Commit Contributions"
+            IsLoading="@_isLoadingHeatmap" />
+    </MudPaper>
+
     <!-- Panels Grid -->
     <div class="panel-grid" style="margin-top: 24px;">
         <DataPanel Title="Activity Overview">
@@ -316,6 +353,11 @@ else
     private PullRequestChartDto? _prChartData;
     private bool _isLoadingPRChart = false;
     private int _selectedPRDays = 30;
+
+    // Heatmap data - Phase 3.4
+    private ContributionHeatmapDto? _heatmapData;
+    private bool _isLoadingHeatmap = false;
+    private int _selectedWeeks = 52;
     protected override async Task OnInitializedAsync()
     {
         _isAuthenticated = await AuthState.IsAuthenticatedAsync();
@@ -326,6 +368,7 @@ else
             await LoadRecentCommitsAsync();
             await LoadCommitActivityAsync(7);
             await LoadPRStatsAsync(30);
+            await LoadHeatmapAsync(52);
         }
         
         // Check if we were redirected back from GitHub OAuth
@@ -518,6 +561,30 @@ else
         finally
         {
             _isLoadingPRChart = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task LoadHeatmapAsync(int weeks)
+    {
+        _selectedWeeks = weeks;
+        _isLoadingHeatmap = true;
+        StateHasChanged();
+
+        try
+        {
+            _heatmapData = await ChartDataService.GetContributionHeatmapAsync(
+                numberOfWeeks: weeks,
+                cancellationToken: default);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading contribution heatmap");
+            Snackbar.Add("Failed to load contribution heatmap", Severity.Error);
+        }
+        finally
+        {
+            _isLoadingHeatmap = false;
             StateHasChanged();
         }
     }

--- a/src/DevMetricsPro.Web/Components/Shared/Charts/ContributionHeatmap.razor
+++ b/src/DevMetricsPro.Web/Components/Shared/Charts/ContributionHeatmap.razor
@@ -1,0 +1,183 @@
+@using DevMetricsPro.Application.DTOs.Charts
+
+<div class="heatmap-container">
+    @if (IsLoading)
+    {
+        <div class="heatmap-loading">
+            <div class="loading-spinner"></div>
+            <span>Loading contribution data...</span>
+        </div>
+    }
+    else if (Data is null || !Data.Days.Any())
+    {
+        <div class="heatmap-empty">
+            <span class="empty-icon">📊</span>
+            <span>No contribution data available</span>
+        </div>
+    }
+    else
+    {
+        <div class="heatmap-header">
+            <h4 class="heatmap-title">@Title</h4>
+            <div class="heatmap-stats">
+                <span class="stat-value">@Data.TotalContributions</span>
+                <span class="stat-label">contributions in the last @Data.NumberOfWeeks weeks</span>
+            </div>
+        </div>
+        
+        <div class="heatmap-content">
+            <!-- Month labels -->
+            <div class="month-labels">
+                @foreach (var month in GetMonthLabels())
+                {
+                    <span class="month-label" style="grid-column: @month.Column;">@month.Name</span>
+                }
+            </div>
+            
+            <!-- Day labels + Grid -->
+            <div class="heatmap-body">
+                <div class="day-labels">
+                    <span></span>
+                    <span>Mon</span>
+                    <span></span>
+                    <span>Wed</span>
+                    <span></span>
+                    <span>Fri</span>
+                    <span></span>
+                </div>
+                
+                <div class="heatmap-grid" style="grid-template-columns: repeat(@GetWeekCount(), 1fr);">
+                    @foreach (var week in GetWeeks())
+                    {
+                        <div class="heatmap-week">
+                            @foreach (var day in week)
+                            {
+                                @if (day is not null)
+                                {
+                                    <div class="heatmap-cell level-@((int)day.Level)"
+                                         title="@day.Date.ToString("MMM dd, yyyy"): @day.Count contribution@(day.Count != 1 ? "s" : "")">
+                                    </div>
+                                }
+                                else
+                                {
+                                    <div class="heatmap-cell empty"></div>
+                                }
+                            }
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+        
+        <!-- Legend -->
+        <div class="heatmap-legend">
+            <span class="legend-label">Less</span>
+            <div class="legend-cell level-0"></div>
+            <div class="legend-cell level-1"></div>
+            <div class="legend-cell level-2"></div>
+            <div class="legend-cell level-3"></div>
+            <div class="legend-cell level-4"></div>
+            <span class="legend-label">More</span>
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public ContributionHeatmapDto? Data { get; set; }
+
+    [Parameter]
+    public string Title { get; set; } = "Contribution Activity";
+
+    [Parameter]
+    public bool IsLoading { get; set; }
+
+    /// <summary>
+    /// Organizes days into weeks (columns) for CSS grid display.
+    /// Each week contains 7 days (Sun-Sat), with nulls for padding.
+    /// </summary>
+    private List<List<DayContribution?>> GetWeeks()
+    {
+        if (Data?.Days is null || !Data.Days.Any())
+            return new List<List<DayContribution?>>();
+
+        var weeks = new List<List<DayContribution?>>();
+        var currentWeek = new List<DayContribution?>();
+        
+        // Pad the first week with empty cells if needed
+        var firstDay = Data.Days.First();
+        var dayOfWeek = (int)firstDay.Date.DayOfWeek;
+        
+        for (var i = 0; i < dayOfWeek; i++)
+        {
+            currentWeek.Add(null);
+        }
+
+        foreach (var day in Data.Days)
+        {
+            currentWeek.Add(day);
+            
+            if (currentWeek.Count == 7)
+            {
+                weeks.Add(currentWeek);
+                currentWeek = new List<DayContribution?>();
+            }
+        }
+
+        // Add the last partial week if any
+        if (currentWeek.Any())
+        {
+            while (currentWeek.Count < 7)
+            {
+                currentWeek.Add(null);
+            }
+            weeks.Add(currentWeek);
+        }
+
+        return weeks;
+    }
+
+    private int GetWeekCount()
+    {
+        return GetWeeks().Count;
+    }
+
+    /// <summary>
+    /// Gets month labels with their grid column positions.
+    /// </summary>
+    private List<(string Name, int Column)> GetMonthLabels()
+    {
+        if (Data?.Days is null || !Data.Days.Any())
+            return new List<(string, int)>();
+
+        var labels = new List<(string Name, int Column)>();
+        var weeks = GetWeeks();
+        
+        string? lastMonth = null;
+        
+        for (var weekIndex = 0; weekIndex < weeks.Count; weekIndex++)
+        {
+            var week = weeks[weekIndex];
+            // Find the first non-null day in the week
+            var firstDay = week.FirstOrDefault(d => d is not null);
+            
+            if (firstDay is not null)
+            {
+                var monthName = firstDay.Date.ToString("MMM");
+                
+                if (monthName != lastMonth)
+                {
+                    // Only show label if we're at the start of a month (day 1-7)
+                    if (firstDay.Date.Day <= 7 || lastMonth is null)
+                    {
+                        labels.Add((monthName, weekIndex + 1)); // CSS grid is 1-based
+                    }
+                    lastMonth = monthName;
+                }
+            }
+        }
+
+        return labels;
+    }
+}
+

--- a/src/DevMetricsPro.Web/Components/Shared/Charts/ContributionHeatmap.razor.css
+++ b/src/DevMetricsPro.Web/Components/Shared/Charts/ContributionHeatmap.razor.css
@@ -1,0 +1,249 @@
+/* Contribution Heatmap - GitHub-style */
+
+.heatmap-container {
+    background: var(--surface-primary, #1a1a2e);
+    border-radius: 8px;
+    padding: 1.5rem;
+    border: 1px solid var(--border-primary, #2d2d44);
+}
+
+/* Loading State */
+.heatmap-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    padding: 3rem;
+    color: var(--text-secondary, #a0a0b0);
+}
+
+.loading-spinner {
+    width: 32px;
+    height: 32px;
+    border: 3px solid var(--border-primary, #2d2d44);
+    border-top-color: var(--accent-primary, #00d4ff);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+/* Empty State */
+.heatmap-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    padding: 3rem;
+    color: var(--text-secondary, #a0a0b0);
+}
+
+.empty-icon {
+    font-size: 2.5rem;
+    opacity: 0.5;
+}
+
+/* Header */
+.heatmap-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.heatmap-title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-primary, #ffffff);
+}
+
+.heatmap-stats {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+}
+
+.stat-value {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--accent-primary, #00d4ff);
+}
+
+.stat-label {
+    font-size: 0.75rem;
+    color: var(--text-secondary, #a0a0b0);
+}
+
+/* Content */
+.heatmap-content {
+    overflow-x: auto;
+}
+
+/* Month Labels */
+.month-labels {
+    display: grid;
+    gap: 0;
+    margin-left: 32px;
+    margin-bottom: 4px;
+    font-size: 0.65rem;
+    color: var(--text-secondary, #a0a0b0);
+    min-height: 14px;
+}
+
+.month-label {
+    white-space: nowrap;
+}
+
+/* Body with Day Labels + Grid */
+.heatmap-body {
+    display: flex;
+    gap: 4px;
+}
+
+/* Day Labels (vertical) */
+.day-labels {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    font-size: 0.6rem;
+    color: var(--text-secondary, #a0a0b0);
+    min-width: 28px;
+    padding-top: 1px;
+}
+
+.day-labels span {
+    height: 12px;
+    display: flex;
+    align-items: center;
+}
+
+/* Grid */
+.heatmap-grid {
+    display: grid;
+    gap: 3px;
+    flex: 1;
+}
+
+.heatmap-week {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+/* Cells */
+.heatmap-cell {
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.heatmap-cell:hover {
+    transform: scale(1.3);
+    box-shadow: 0 0 8px rgba(0, 212, 255, 0.4);
+    z-index: 10;
+    position: relative;
+}
+
+.heatmap-cell.empty {
+    visibility: hidden;
+}
+
+/* Contribution Levels - GitHub-inspired colors */
+.heatmap-cell.level-0 {
+    background-color: var(--contribution-none, #161b22);
+    border: 1px solid var(--border-primary, #2d2d44);
+}
+
+.heatmap-cell.level-1 {
+    background-color: var(--contribution-low, #0e4429);
+}
+
+.heatmap-cell.level-2 {
+    background-color: var(--contribution-medium, #006d32);
+}
+
+.heatmap-cell.level-3 {
+    background-color: var(--contribution-high, #26a641);
+}
+
+.heatmap-cell.level-4 {
+    background-color: var(--contribution-max, #39d353);
+}
+
+/* Legend */
+.heatmap-legend {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 4px;
+    margin-top: 1rem;
+    font-size: 0.65rem;
+    color: var(--text-secondary, #a0a0b0);
+}
+
+.legend-label {
+    padding: 0 4px;
+}
+
+.legend-cell {
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+}
+
+.legend-cell.level-0 {
+    background-color: var(--contribution-none, #161b22);
+    border: 1px solid var(--border-primary, #2d2d44);
+}
+
+.legend-cell.level-1 {
+    background-color: var(--contribution-low, #0e4429);
+}
+
+.legend-cell.level-2 {
+    background-color: var(--contribution-medium, #006d32);
+}
+
+.legend-cell.level-3 {
+    background-color: var(--contribution-high, #26a641);
+}
+
+.legend-cell.level-4 {
+    background-color: var(--contribution-max, #39d353);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .heatmap-container {
+        padding: 1rem;
+    }
+    
+    .heatmap-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    
+    .heatmap-cell {
+        width: 10px;
+        height: 10px;
+    }
+    
+    .legend-cell {
+        width: 10px;
+        height: 10px;
+    }
+    
+    .day-labels span {
+        height: 10px;
+    }
+}
+


### PR DESCRIPTION
- Create ContributionHeatmapDto with DayContribution and ContributionLevel
- Add GetContributionHeatmapAsync to IChartDataService
- Implement heatmap data aggregation in ChartDataService
- Create ContributionHeatmap.razor component with CSS grid layout
- Add 5 contribution levels with GitHub-inspired green colors
- Include time range selector (3mo, 6mo, 1yr)
- Add hover tooltips, day labels, month labels
- Responsive design with horizontal scrolling on mobile

Closes #118

<!-- GitHub auto-fills description from commits below -->

## ✅ Ready to Merge?
- [x] Builds successfully
- [x] CI checks passing
- [x] Tested locally

