### PR TITLE
feat(leaderboard): add team leaderboard component #120

### DIFF
--- a/src/DevMetricsPro.Application/DTOs/LeaderboardEntryDto.cs
+++ b/src/DevMetricsPro.Application/DTOs/LeaderboardEntryDto.cs
@@ -1,0 +1,53 @@
+namespace DevMetricsPro.Application.DTOs;
+
+/// <summary>
+/// Data transfer object for a single leaderboard entry
+/// </summary>
+public record LeaderboardEntryDto
+{
+    /// <summary>
+    /// Current rank position (1-based)
+    /// </summary>
+    public int Rank { get; init; }
+
+    /// <summary>
+    /// Developer's unique identifier
+    /// </summary>
+    public Guid DeveloperId { get; init; }
+
+    /// <summary>
+    /// Developer's display name or username
+    /// </summary>
+    public required string DeveloperName { get; init; }
+
+    /// <summary>
+    /// Developer's avatar URL (optional)
+    /// </summary>
+    public string? AvatarUrl { get; init; }
+
+    /// <summary>
+    /// The metric value (e.g., commit count, PR count)
+    /// </summary>
+    public int Value { get; init; }
+
+    /// <summary>
+    /// Change indicator compared to previous period (e.g., "+5", "-2", "0")
+    /// </summary>
+    public string Change { get; init; } = "0";
+
+    /// <summary>
+    /// Whether the change is positive, negative, or neutral
+    /// </summary>
+    public TrendDirection Trend { get; init; } = TrendDirection.Neutral;
+}
+
+/// <summary>
+/// Direction of trend change
+/// </summary>
+public enum TrendDirection
+{
+    Up,
+    Down,
+    Neutral
+}
+

--- a/src/DevMetricsPro.Application/Enums/LeaderboardMetric.cs
+++ b/src/DevMetricsPro.Application/Enums/LeaderboardMetric.cs
@@ -1,0 +1,28 @@
+namespace DevMetricsPro.Application.Enums;
+
+/// <summary>
+/// Metrics available for leaderboard ranking
+/// </summary>
+public enum LeaderboardMetric
+{
+    /// <summary>
+    /// Total number of commits
+    /// </summary>
+    Commits,
+
+    /// <summary>
+    /// Total number of pull requests
+    /// </summary>
+    PullRequests,
+
+    /// <summary>
+    /// Total lines of code changed (additions + deletions)
+    /// </summary>
+    LinesChanged,
+
+    /// <summary>
+    /// Number of days with at least one contribution
+    /// </summary>
+    ActiveDays
+}
+

--- a/src/DevMetricsPro.Application/Interfaces/ILeaderboardService.cs
+++ b/src/DevMetricsPro.Application/Interfaces/ILeaderboardService.cs
@@ -1,0 +1,27 @@
+using DevMetricsPro.Application.DTOs;
+using DevMetricsPro.Application.Enums;
+
+namespace DevMetricsPro.Application.Interfaces;
+
+/// <summary>
+/// Service for retrieving leaderboard data
+/// </summary>
+public interface ILeaderboardService
+{
+    /// <summary>
+    /// Get top contributors for a specific metric
+    /// </summary>
+    /// <param name="metric">The metric to rank by</param>
+    /// <param name="topN">Number of top entries to return</param>
+    /// <param name="startDate">Start of the time range</param>
+    /// <param name="endDate">End of the time range</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of leaderboard entries sorted by rank</returns>
+    Task<List<LeaderboardEntryDto>> GetLeaderboardAsync(
+        LeaderboardMetric metric,
+        int topN,
+        DateTime startDate,
+        DateTime endDate,
+        CancellationToken cancellationToken = default);
+}
+

--- a/src/DevMetricsPro.Application/Services/LeaderboardService.cs
+++ b/src/DevMetricsPro.Application/Services/LeaderboardService.cs
@@ -1,0 +1,184 @@
+using DevMetricsPro.Application.DTOs;
+using DevMetricsPro.Application.Enums;
+using DevMetricsPro.Application.Interfaces;
+using DevMetricsPro.Core.Entities;
+using DevMetricsPro.Core.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace DevMetricsPro.Application.Services;
+
+/// <summary>
+/// Service for retrieving leaderboard data
+/// </summary>
+public class LeaderboardService : ILeaderboardService
+{
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<LeaderboardService> _logger;
+
+    public LeaderboardService(
+        IUnitOfWork unitOfWork,
+        ILogger<LeaderboardService> logger)
+    {
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+
+    public async Task<List<LeaderboardEntryDto>> GetLeaderboardAsync(
+        LeaderboardMetric metric,
+        int topN,
+        DateTime startDate,
+        DateTime endDate,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation(
+            "Fetching leaderboard for {Metric}, top {TopN}, from {StartDate} to {EndDate}",
+            metric, topN, startDate, endDate);
+
+        return metric switch
+        {
+            LeaderboardMetric.Commits => await GetCommitsLeaderboardAsync(topN, startDate, endDate, cancellationToken),
+            LeaderboardMetric.PullRequests => await GetPullRequestsLeaderboardAsync(topN, startDate, endDate, cancellationToken),
+            LeaderboardMetric.LinesChanged => await GetLinesChangedLeaderboardAsync(topN, startDate, endDate, cancellationToken),
+            LeaderboardMetric.ActiveDays => await GetActiveDaysLeaderboardAsync(topN, startDate, endDate, cancellationToken),
+            _ => throw new ArgumentOutOfRangeException(nameof(metric), metric, "Unknown leaderboard metric")
+        };
+    }
+
+    private async Task<List<LeaderboardEntryDto>> GetCommitsLeaderboardAsync(
+        int topN,
+        DateTime startDate,
+        DateTime endDate,
+        CancellationToken cancellationToken)
+    {
+        var leaderboard = await _unitOfWork.Repository<Commit>()
+            .Query()
+            .AsNoTracking()
+            .Where(c => c.CommittedAt >= startDate && c.CommittedAt <= endDate)
+            .GroupBy(c => c.Developer)
+            .Select(g => new
+            {
+                Developer = g.Key,
+                Count = g.Count()
+            })
+            .OrderByDescending(x => x.Count)
+            .Take(topN)
+            .ToListAsync(cancellationToken);
+
+        return leaderboard
+            .Select((entry, index) => new LeaderboardEntryDto
+            {
+                Rank = index + 1,
+                DeveloperId = entry.Developer.Id,
+                DeveloperName = entry.Developer.DisplayName ?? entry.Developer.GitHubUsername ?? entry.Developer.Email,
+                AvatarUrl = entry.Developer.AvatarUrl,
+                Value = entry.Count,
+                Change = "0", // TODO: Calculate trend from previous period
+                Trend = TrendDirection.Neutral
+            })
+            .ToList();
+    }
+
+    private async Task<List<LeaderboardEntryDto>> GetPullRequestsLeaderboardAsync(
+        int topN,
+        DateTime startDate,
+        DateTime endDate,
+        CancellationToken cancellationToken)
+    {
+        var leaderboard = await _unitOfWork.Repository<PullRequest>()
+            .Query()
+            .AsNoTracking()
+            .Where(pr => pr.CreatedAt >= startDate && pr.CreatedAt <= endDate)
+            .GroupBy(pr => pr.Author)
+            .Select(g => new
+            {
+                Developer = g.Key,
+                Count = g.Count()
+            })
+            .OrderByDescending(x => x.Count)
+            .Take(topN)
+            .ToListAsync(cancellationToken);
+
+        return leaderboard
+            .Select((entry, index) => new LeaderboardEntryDto
+            {
+                Rank = index + 1,
+                DeveloperId = entry.Developer.Id,
+                DeveloperName = entry.Developer.DisplayName ?? entry.Developer.GitHubUsername ?? entry.Developer.Email,
+                AvatarUrl = entry.Developer.AvatarUrl,
+                Value = entry.Count,
+                Change = "0",
+                Trend = TrendDirection.Neutral
+            })
+            .ToList();
+    }
+
+    private async Task<List<LeaderboardEntryDto>> GetLinesChangedLeaderboardAsync(
+        int topN,
+        DateTime startDate,
+        DateTime endDate,
+        CancellationToken cancellationToken)
+    {
+        var leaderboard = await _unitOfWork.Repository<Commit>()
+            .Query()
+            .AsNoTracking()
+            .Where(c => c.CommittedAt >= startDate && c.CommittedAt <= endDate)
+            .GroupBy(c => c.Developer)
+            .Select(g => new
+            {
+                Developer = g.Key,
+                LinesChanged = g.Sum(c => c.LinesAdded + c.LinesRemoved)
+            })
+            .OrderByDescending(x => x.LinesChanged)
+            .Take(topN)
+            .ToListAsync(cancellationToken);
+
+        return leaderboard
+            .Select((entry, index) => new LeaderboardEntryDto
+            {
+                Rank = index + 1,
+                DeveloperId = entry.Developer.Id,
+                DeveloperName = entry.Developer.DisplayName ?? entry.Developer.GitHubUsername ?? entry.Developer.Email,
+                AvatarUrl = entry.Developer.AvatarUrl,
+                Value = entry.LinesChanged,
+                Change = "0",
+                Trend = TrendDirection.Neutral
+            })
+            .ToList();
+    }
+
+    private async Task<List<LeaderboardEntryDto>> GetActiveDaysLeaderboardAsync(
+        int topN,
+        DateTime startDate,
+        DateTime endDate,
+        CancellationToken cancellationToken)
+    {
+        var leaderboard = await _unitOfWork.Repository<Commit>()
+            .Query()
+            .AsNoTracking()
+            .Where(c => c.CommittedAt >= startDate && c.CommittedAt <= endDate)
+            .GroupBy(c => c.Developer)
+            .Select(g => new
+            {
+                Developer = g.Key,
+                ActiveDays = g.Select(c => c.CommittedAt.Date).Distinct().Count()
+            })
+            .OrderByDescending(x => x.ActiveDays)
+            .Take(topN)
+            .ToListAsync(cancellationToken);
+
+        return leaderboard
+            .Select((entry, index) => new LeaderboardEntryDto
+            {
+                Rank = index + 1,
+                DeveloperId = entry.Developer.Id,
+                DeveloperName = entry.Developer.DisplayName ?? entry.Developer.GitHubUsername ?? entry.Developer.Email,
+                AvatarUrl = entry.Developer.AvatarUrl,
+                Value = entry.ActiveDays,
+                Change = "0",
+                Trend = TrendDirection.Neutral
+            })
+            .ToList();
+    }
+}
+

--- a/src/DevMetricsPro.Web/Components/Pages/Home.razor
+++ b/src/DevMetricsPro.Web/Components/Pages/Home.razor
@@ -1,10 +1,14 @@
 ﻿@page "/"
+@using DevMetricsPro.Application.DTOs
 @using DevMetricsPro.Application.DTOs.Charts
+@using DevMetricsPro.Application.Enums
 @using DevMetricsPro.Application.Interfaces
+@using DevMetricsPro.Web.Components.Shared
 @using DevMetricsPro.Web.Components.Shared.Charts
 @using DevMetricsPro.Web.Services
 @inject AuthStateService AuthState
 @inject IChartDataService ChartDataService
+@inject ILeaderboardService LeaderboardService
 @inject HttpClient Http
 @inject NavigationManager Navigation
 @inject ILogger<Home> Logger
@@ -249,6 +253,19 @@ else
             IsLoading="@_isLoadingHeatmap" />
     </MudPaper>
 
+    <!-- Team Leaderboard - Phase 3.5 -->
+    <MudPaper Class="pa-4 mt-4">
+        <MudText Typo="Typo.h5" Class="mb-4">🏆 Top Contributors (Last 30 Days)</MudText>
+        
+        <Leaderboard 
+            Entries="@_leaderboardEntries"
+            Title="Team Leaderboard"
+            IsLoading="@_isLoadingLeaderboard"
+            ShowMetricSelector="true"
+            SelectedMetric="@_selectedMetric"
+            OnMetricChanged="OnLeaderboardMetricChanged" />
+    </MudPaper>
+
     <!-- Panels Grid -->
     <div class="panel-grid" style="margin-top: 24px;">
         <DataPanel Title="Activity Overview">
@@ -358,6 +375,11 @@ else
     private ContributionHeatmapDto? _heatmapData;
     private bool _isLoadingHeatmap = false;
     private int _selectedWeeks = 52;
+
+    // Leaderboard data - Phase 3.5
+    private List<LeaderboardEntryDto>? _leaderboardEntries;
+    private bool _isLoadingLeaderboard = false;
+    private LeaderboardMetric _selectedMetric = LeaderboardMetric.Commits;
     protected override async Task OnInitializedAsync()
     {
         _isAuthenticated = await AuthState.IsAuthenticatedAsync();
@@ -369,6 +391,7 @@ else
             await LoadCommitActivityAsync(7);
             await LoadPRStatsAsync(30);
             await LoadHeatmapAsync(52);
+            await LoadLeaderboardAsync(_selectedMetric);
         }
         
         // Check if we were redirected back from GitHub OAuth
@@ -587,6 +610,41 @@ else
             _isLoadingHeatmap = false;
             StateHasChanged();
         }
+    }
+
+    private async Task LoadLeaderboardAsync(LeaderboardMetric metric)
+    {
+        _selectedMetric = metric;
+        _isLoadingLeaderboard = true;
+        StateHasChanged();
+
+        try
+        {
+            var endDate = DateTime.UtcNow;
+            var startDate = endDate.AddDays(-30); // Last 30 days
+
+            _leaderboardEntries = await LeaderboardService.GetLeaderboardAsync(
+                metric: metric,
+                topN: 10,
+                startDate: startDate,
+                endDate: endDate,
+                cancellationToken: default);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error loading leaderboard");
+            Snackbar.Add("Failed to load leaderboard", Severity.Error);
+        }
+        finally
+        {
+            _isLoadingLeaderboard = false;
+            StateHasChanged();
+        }
+    }
+
+    private async Task OnLeaderboardMetricChanged(LeaderboardMetric metric)
+    {
+        await LoadLeaderboardAsync(metric);
     }
 
     // Helper classes for deserializing API responses

--- a/src/DevMetricsPro.Web/Components/Shared/Leaderboard.razor
+++ b/src/DevMetricsPro.Web/Components/Shared/Leaderboard.razor
@@ -1,0 +1,155 @@
+@using DevMetricsPro.Application.DTOs
+@using DevMetricsPro.Application.Enums
+
+<div class="leaderboard-container">
+    @if (IsLoading)
+    {
+        <div class="leaderboard-loading">
+            <div class="loading-spinner"></div>
+            <span>Loading leaderboard...</span>
+        </div>
+    }
+    else if (Entries is null || !Entries.Any())
+    {
+        <div class="leaderboard-empty">
+            <span class="empty-icon">🏆</span>
+            <span>No leaderboard data available</span>
+        </div>
+    }
+    else
+    {
+        <div class="leaderboard-header">
+            <h4 class="leaderboard-title">@Title</h4>
+            @if (ShowMetricSelector)
+            {
+                <div class="metric-selector">
+                    <select @bind="SelectedMetric" @bind:after="OnMetricChangedAsync" class="metric-dropdown">
+                        <option value="@LeaderboardMetric.Commits">Commits</option>
+                        <option value="@LeaderboardMetric.PullRequests">Pull Requests</option>
+                        <option value="@LeaderboardMetric.LinesChanged">Lines Changed</option>
+                        <option value="@LeaderboardMetric.ActiveDays">Active Days</option>
+                    </select>
+                </div>
+            }
+        </div>
+
+        <div class="leaderboard-list">
+            @foreach (var entry in Entries)
+            {
+                <div class="leaderboard-entry @GetRankClass(entry.Rank)">
+                    <div class="rank-badge">
+                        @if (entry.Rank <= 3)
+                        {
+                            <span class="trophy">@GetTrophy(entry.Rank)</span>
+                        }
+                        else
+                        {
+                            <span class="rank-number">@entry.Rank</span>
+                        }
+                    </div>
+
+                    <div class="developer-info">
+                        @if (!string.IsNullOrEmpty(entry.AvatarUrl))
+                        {
+                            <img src="@entry.AvatarUrl" alt="@entry.DeveloperName" class="avatar" />
+                        }
+                        else
+                        {
+                            <div class="avatar-placeholder">
+                                @GetInitials(entry.DeveloperName)
+                            </div>
+                        }
+                        <span class="developer-name">@entry.DeveloperName</span>
+                    </div>
+
+                    <div class="value-info">
+                        <span class="value">@FormatValue(entry.Value)</span>
+                        <span class="trend @GetTrendClass(entry.Trend)">
+                            @GetTrendIcon(entry.Trend) @entry.Change
+                        </span>
+                    </div>
+                </div>
+            }
+        </div>
+    }
+</div>
+
+@code {
+    [Parameter]
+    public List<LeaderboardEntryDto>? Entries { get; set; }
+
+    [Parameter]
+    public string Title { get; set; } = "Top Contributors";
+
+    [Parameter]
+    public bool IsLoading { get; set; }
+
+    [Parameter]
+    public bool ShowMetricSelector { get; set; } = true;
+
+    [Parameter]
+    public LeaderboardMetric SelectedMetric { get; set; } = LeaderboardMetric.Commits;
+
+    [Parameter]
+    public EventCallback<LeaderboardMetric> OnMetricChanged { get; set; }
+
+    private async Task OnMetricChangedAsync()
+    {
+        await OnMetricChanged.InvokeAsync(SelectedMetric);
+    }
+
+    private static string GetTrophy(int rank) => rank switch
+    {
+        1 => "🥇",
+        2 => "🥈",
+        3 => "🥉",
+        _ => ""
+    };
+
+    private static string GetRankClass(int rank) => rank switch
+    {
+        1 => "rank-gold",
+        2 => "rank-silver",
+        3 => "rank-bronze",
+        _ => ""
+    };
+
+    private static string GetTrendIcon(TrendDirection trend) => trend switch
+    {
+        TrendDirection.Up => "↑",
+        TrendDirection.Down => "↓",
+        _ => ""
+    };
+
+    private static string GetTrendClass(TrendDirection trend) => trend switch
+    {
+        TrendDirection.Up => "trend-up",
+        TrendDirection.Down => "trend-down",
+        _ => "trend-neutral"
+    };
+
+    private static string GetInitials(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+            return "?";
+
+        var parts = name.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length >= 2)
+            return $"{parts[0][0]}{parts[1][0]}".ToUpper();
+
+        return name.Length >= 2 
+            ? name[..2].ToUpper() 
+            : name.ToUpper();
+    }
+
+    private static string FormatValue(int value)
+    {
+        return value switch
+        {
+            >= 1000000 => $"{value / 1000000.0:F1}M",
+            >= 1000 => $"{value / 1000.0:F1}K",
+            _ => value.ToString()
+        };
+    }
+}
+

--- a/src/DevMetricsPro.Web/Components/Shared/Leaderboard.razor.css
+++ b/src/DevMetricsPro.Web/Components/Shared/Leaderboard.razor.css
@@ -1,0 +1,250 @@
+.leaderboard-container {
+    background: var(--mud-palette-surface);
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+/* Header */
+.leaderboard-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+}
+
+.leaderboard-title {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--mud-palette-text-primary);
+}
+
+/* Metric Selector */
+.metric-selector {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.metric-dropdown {
+    padding: 0.5rem 1rem;
+    border-radius: 8px;
+    border: 1px solid var(--mud-palette-lines-default);
+    background: var(--mud-palette-background);
+    color: var(--mud-palette-text-primary);
+    font-size: 0.875rem;
+    cursor: pointer;
+    transition: border-color 0.2s;
+}
+
+.metric-dropdown:hover {
+    border-color: var(--mud-palette-primary);
+}
+
+.metric-dropdown:focus {
+    outline: none;
+    border-color: var(--mud-palette-primary);
+    box-shadow: 0 0 0 2px rgba(var(--mud-palette-primary-rgb), 0.2);
+}
+
+/* Leaderboard List */
+.leaderboard-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+/* Entry */
+.leaderboard-entry {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1rem;
+    background: var(--mud-palette-background);
+    border-radius: 8px;
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.leaderboard-entry:hover {
+    transform: translateX(4px);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+/* Rank styling */
+.leaderboard-entry.rank-gold {
+    background: linear-gradient(135deg, rgba(255, 215, 0, 0.1), rgba(255, 215, 0, 0.05));
+    border: 1px solid rgba(255, 215, 0, 0.3);
+}
+
+.leaderboard-entry.rank-silver {
+    background: linear-gradient(135deg, rgba(192, 192, 192, 0.1), rgba(192, 192, 192, 0.05));
+    border: 1px solid rgba(192, 192, 192, 0.3);
+}
+
+.leaderboard-entry.rank-bronze {
+    background: linear-gradient(135deg, rgba(205, 127, 50, 0.1), rgba(205, 127, 50, 0.05));
+    border: 1px solid rgba(205, 127, 50, 0.3);
+}
+
+/* Rank Badge */
+.rank-badge {
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.trophy {
+    font-size: 1.5rem;
+}
+
+.rank-number {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--mud-palette-text-secondary);
+    background: var(--mud-palette-surface);
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Developer Info */
+.developer-info {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex: 1;
+    min-width: 0;
+}
+
+.avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+}
+
+.avatar-placeholder {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--mud-palette-primary), var(--mud-palette-secondary));
+    color: white;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.875rem;
+    font-weight: 600;
+    flex-shrink: 0;
+}
+
+.developer-name {
+    font-weight: 500;
+    color: var(--mud-palette-text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Value Info */
+.value-info {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.25rem;
+}
+
+.value {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--mud-palette-text-primary);
+}
+
+.trend {
+    font-size: 0.75rem;
+    font-weight: 500;
+}
+
+.trend-up {
+    color: #22c55e;
+}
+
+.trend-down {
+    color: #ef4444;
+}
+
+.trend-neutral {
+    color: var(--mud-palette-text-secondary);
+}
+
+/* Loading State */
+.leaderboard-loading {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 3rem;
+    gap: 1rem;
+    color: var(--mud-palette-text-secondary);
+}
+
+.loading-spinner {
+    width: 40px;
+    height: 40px;
+    border: 3px solid var(--mud-palette-lines-default);
+    border-top-color: var(--mud-palette-primary);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+/* Empty State */
+.leaderboard-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 3rem;
+    gap: 0.5rem;
+    color: var(--mud-palette-text-secondary);
+}
+
+.empty-icon {
+    font-size: 3rem;
+    opacity: 0.5;
+}
+
+/* Responsive */
+@media (max-width: 480px) {
+    .leaderboard-container {
+        padding: 1rem;
+    }
+
+    .leaderboard-header {
+        flex-direction: column;
+        gap: 1rem;
+        align-items: flex-start;
+    }
+
+    .leaderboard-entry {
+        padding: 0.75rem;
+    }
+
+    .developer-name {
+        max-width: 120px;
+    }
+
+    .value {
+        font-size: 1rem;
+    }
+}
+

--- a/src/DevMetricsPro.Web/Program.cs
+++ b/src/DevMetricsPro.Web/Program.cs
@@ -117,7 +117,10 @@ try
     builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
 
     // Chart data services
-builder.Services.AddScoped<IChartDataService, ChartDataService>();
+    builder.Services.AddScoped<IChartDataService, ChartDataService>();
+    
+    // Leaderboard services
+    builder.Services.AddScoped<ILeaderboardService, LeaderboardService>();
     
     // Authentication state service
     builder.Services.AddScoped<AuthStateService>();


### PR DESCRIPTION
- Create LeaderboardMetric enum (Commits, PullRequests, LinesChanged, ActiveDays)
- Create LeaderboardEntryDto with rank, developer info, value, trend
- Create ILeaderboardService interface with GetLeaderboardAsync method
- Implement LeaderboardService with 4 metric queries
- Create Leaderboard.razor component with trophy icons
- Add gold/silver/bronze rank styling and trend indicators
- Add metric selector dropdown for switching metrics
- Integrate into Home.razor dashboard

Closes #120

<!-- GitHub auto-fills description from commits below -->

## ✅ Ready to Merge?
- [x] Builds successfully
- [x] CI checks passing
- [x] Tested locally

