### PR TITLE
feat(signalr): implement client-side SignalR for real-time dashboard

### DIFF
--- a/src/DevMetricsPro.Web/Components/Pages/Home.razor
+++ b/src/DevMetricsPro.Web/Components/Pages/Home.razor
@@ -6,15 +6,37 @@
 @using DevMetricsPro.Web.Components.Shared
 @using DevMetricsPro.Web.Components.Shared.Charts
 @using DevMetricsPro.Web.Services
+@using Microsoft.AspNetCore.SignalR.Client
+@implements IAsyncDisposable
 @inject AuthStateService AuthState
 @inject IChartDataService ChartDataService
 @inject ILeaderboardService LeaderboardService
+@inject SignalRService SignalR
 @inject HttpClient Http
 @inject NavigationManager Navigation
 @inject ILogger<Home> Logger
 @inject ISnackbar Snackbar
 
 <PageTitle>Dashboard - DevMetrics Pro</PageTitle>
+
+<!-- Sync Status Indicator -->
+@if (_isSyncing)
+{
+    <MudAlert Severity="Severity.Info" Class="mb-4" Icon="@Icons.Material.Filled.Sync">
+        <div style="display: flex; align-items: center; gap: 12px;">
+            <MudProgressCircular Size="Size.Small" Indeterminate="true" />
+            <span>Syncing data from GitHub... Dashboard will update automatically.</span>
+        </div>
+    </MudAlert>
+}
+
+<!-- Connection Status (only show when disconnected) -->
+@if (_isAuthenticated && !_isSignalRConnected && _signalRConnectionAttempted)
+{
+    <MudAlert Severity="Severity.Warning" Class="mb-4" Icon="@Icons.Material.Filled.CloudOff">
+        <span>Real-time updates unavailable. Data will still refresh on page reload.</span>
+    </MudAlert>
+}
 
 @if (!_isAuthenticated)
 {
@@ -380,18 +402,31 @@ else
     private List<LeaderboardEntryDto>? _leaderboardEntries;
     private bool _isLoadingLeaderboard = false;
     private LeaderboardMetric _selectedMetric = LeaderboardMetric.Commits;
+
+    // SignalR state - Phase 3.7
+    private bool _isSyncing = false;
+    private bool _isSignalRConnected = false;
+    private bool _signalRConnectionAttempted = false;
+    private string? _currentUserId;
+
     protected override async Task OnInitializedAsync()
     {
         _isAuthenticated = await AuthState.IsAuthenticatedAsync();
         
         if (_isAuthenticated)
         {
+            // Get user ID for SignalR
+            _currentUserId = await AuthState.GetUserIdAsync();
+            
             await CheckGitHubConnectionStatus();
             await LoadRecentCommitsAsync();
             await LoadCommitActivityAsync(7);
             await LoadPRStatsAsync(30);
             await LoadHeatmapAsync(52);
             await LoadLeaderboardAsync(_selectedMetric);
+
+            // Initialize SignalR connection
+            await InitializeSignalRAsync();
         }
         
         // Check if we were redirected back from GitHub OAuth
@@ -402,6 +437,117 @@ else
             githubConnectedMessage = "GitHub account connected successfully!";
             await CheckGitHubConnectionStatus(); // Refresh status
         }
+    }
+
+    private async Task InitializeSignalRAsync()
+    {
+        if (string.IsNullOrEmpty(_currentUserId))
+            return;
+
+        try
+        {
+            // Register event handlers
+            SignalR.OnSyncStarted += HandleSyncStarted;
+            SignalR.OnSyncCompleted += HandleSyncCompleted;
+            SignalR.OnMetricsUpdated += HandleMetricsUpdated;
+            SignalR.OnConnectionStateChanged += HandleConnectionStateChanged;
+
+            // Start connection
+            await SignalR.StartAsync(_currentUserId);
+            _isSignalRConnected = true;
+            _signalRConnectionAttempted = true;
+
+            Logger.LogInformation("SignalR connected for dashboard updates");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to initialize SignalR connection");
+            _isSignalRConnected = false;
+            _signalRConnectionAttempted = true;
+            // Don't show error - dashboard still works without real-time updates
+        }
+    }
+
+    private async Task HandleSyncStarted()
+    {
+        await InvokeAsync(() =>
+        {
+            _isSyncing = true;
+            StateHasChanged();
+        });
+    }
+
+    private async Task HandleSyncCompleted(SyncResultDto result)
+    {
+        await InvokeAsync(async () =>
+        {
+            _isSyncing = false;
+
+            if (result.Success)
+            {
+                // Show success notification
+                Snackbar.Add(
+                    $"Sync complete! {result.RepositoriesSynced} repos, {result.CommitsSynced} commits, {result.PullRequestsSynced} PRs",
+                    Severity.Success,
+                    config => config.Icon = Icons.Material.Filled.CheckCircle);
+
+                // Refresh all dashboard data
+                await RefreshAllDataAsync();
+            }
+            else
+            {
+                Snackbar.Add(
+                    $"Sync failed: {result.ErrorMessage ?? "Unknown error"}",
+                    Severity.Error,
+                    config => config.Icon = Icons.Material.Filled.Error);
+            }
+
+            StateHasChanged();
+        });
+    }
+
+    private async Task HandleMetricsUpdated()
+    {
+        await InvokeAsync(async () =>
+        {
+            Snackbar.Add("Metrics updated!", Severity.Info, config => config.Icon = Icons.Material.Filled.Refresh);
+            await RefreshAllDataAsync();
+            StateHasChanged();
+        });
+    }
+
+    private void HandleConnectionStateChanged(HubConnectionState state)
+    {
+        InvokeAsync(() =>
+        {
+            _isSignalRConnected = state == HubConnectionState.Connected;
+            
+            if (state == HubConnectionState.Reconnecting)
+            {
+                Snackbar.Add("Connection lost. Reconnecting...", Severity.Warning);
+            }
+            else if (state == HubConnectionState.Connected && _signalRConnectionAttempted)
+            {
+                Snackbar.Add("Reconnected!", Severity.Success);
+            }
+            
+            StateHasChanged();
+        });
+    }
+
+    private async Task RefreshAllDataAsync()
+    {
+        // Reload all data in parallel for efficiency
+        var tasks = new List<Task>
+        {
+            LoadRecentCommitsAsync(),
+            LoadCommitActivityAsync(_selectedDays),
+            LoadPRStatsAsync(_selectedPRDays),
+            LoadHeatmapAsync(_selectedWeeks),
+            LoadLeaderboardAsync(_selectedMetric)
+        };
+
+        await Task.WhenAll(tasks);
     }
 
     private async Task CheckGitHubConnectionStatus()
@@ -678,5 +824,28 @@ else
         public string RepositoryName { get; set; } = string.Empty;
         public int LinesAdded { get; set; }
         public int LinesRemoved { get; set; }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        // Unregister event handlers
+        SignalR.OnSyncStarted -= HandleSyncStarted;
+        SignalR.OnSyncCompleted -= HandleSyncCompleted;
+        SignalR.OnMetricsUpdated -= HandleMetricsUpdated;
+        SignalR.OnConnectionStateChanged -= HandleConnectionStateChanged;
+
+        // Note: Don't dispose SignalR service here as it's managed by DI
+        // Just leave the dashboard group
+        if (!string.IsNullOrEmpty(_currentUserId))
+        {
+            try
+            {
+                await SignalR.LeaveDashboardAsync();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogWarning(ex, "Error leaving dashboard group during dispose");
+            }
+        }
     }
 }

--- a/src/DevMetricsPro.Web/DevMetricsPro.Web.csproj
+++ b/src/DevMetricsPro.Web/DevMetricsPro.Web.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Hangfire.PostgreSql" Version="1.20.12" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.10">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/DevMetricsPro.Web/Program.cs
+++ b/src/DevMetricsPro.Web/Program.cs
@@ -170,6 +170,7 @@ try
     // SignalR for real-time updates
     builder.Services.AddSignalR();
     builder.Services.AddScoped<IMetricsHubService, MetricsHubService>();
+    builder.Services.AddScoped<SignalRService>();
 
     // Configure application cookie
     builder.Services.ConfigureApplicationCookie(options =>

--- a/src/DevMetricsPro.Web/Services/AuthStateService.cs
+++ b/src/DevMetricsPro.Web/Services/AuthStateService.cs
@@ -99,6 +99,29 @@ public class AuthStateService
             return null;
         }
     }
+
+    /// <summary>
+    /// Get the user ID from the JWT token
+    /// </summary>
+    /// <returns>The user ID or null if not found</returns>
+    public async Task<string?> GetUserIdAsync()
+    {
+        var token = await GetTokenAsync();
+        if (string.IsNullOrEmpty(token)) return null;
+
+        try
+        {
+            var jwtToken = new JwtSecurityTokenHandler().ReadJwtToken(token);
+            // Try standard claims first, then JWT-specific ones
+            return jwtToken.Claims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier)?.Value
+                ?? jwtToken.Claims.FirstOrDefault(c => c.Type == "sub")?.Value
+                ?? jwtToken.Claims.FirstOrDefault(c => c.Type == "userId")?.Value;
+        }
+        catch
+        {
+            return null;
+        }
+    }
 }
 
 public class UserInfo

--- a/src/DevMetricsPro.Web/Services/SignalRService.cs
+++ b/src/DevMetricsPro.Web/Services/SignalRService.cs
@@ -1,0 +1,198 @@
+using DevMetricsPro.Application.DTOs;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace DevMetricsPro.Web.Services;
+
+/// <summary>
+/// Client-side SignalR service for real-time dashboard updates.
+/// Manages connection lifecycle and event handling.
+/// </summary>
+public class SignalRService : IAsyncDisposable
+{
+    private readonly NavigationManager _navigationManager;
+    private readonly ILogger<SignalRService> _logger;
+    private HubConnection? _hubConnection;
+    private string? _currentUserId;
+
+    /// <summary>
+    /// Fired when sync operation starts
+    /// </summary>
+    public event Func<Task>? OnSyncStarted;
+
+    /// <summary>
+    /// Fired when sync operation completes
+    /// </summary>
+    public event Func<SyncResultDto, Task>? OnSyncCompleted;
+
+    /// <summary>
+    /// Fired when metrics are updated
+    /// </summary>
+    public event Func<Task>? OnMetricsUpdated;
+
+    /// <summary>
+    /// Fired when connection state changes
+    /// </summary>
+    public event Action<HubConnectionState>? OnConnectionStateChanged;
+
+    /// <summary>
+    /// Current connection state
+    /// </summary>
+    public HubConnectionState ConnectionState => _hubConnection?.State ?? HubConnectionState.Disconnected;
+
+    /// <summary>
+    /// Whether the connection is established
+    /// </summary>
+    public bool IsConnected => _hubConnection?.State == HubConnectionState.Connected;
+
+    public SignalRService(
+        NavigationManager navigationManager,
+        ILogger<SignalRService> logger)
+    {
+        _navigationManager = navigationManager;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Start the SignalR connection and join the user's dashboard group
+    /// </summary>
+    /// <param name="userId">The user ID to subscribe to updates for</param>
+    public async Task StartAsync(string userId)
+    {
+        if (_hubConnection != null)
+        {
+            _logger.LogWarning("SignalR connection already exists, disposing old connection");
+            await DisposeAsync();
+        }
+
+        _currentUserId = userId;
+
+        try
+        {
+            _hubConnection = new HubConnectionBuilder()
+                .WithUrl(_navigationManager.ToAbsoluteUri("/hubs/metrics"))
+                .WithAutomaticReconnect(new[] { TimeSpan.Zero, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10) })
+                .Build();
+
+            // Register event handlers
+            _hubConnection.On("SyncStarted", async (object data) =>
+            {
+                _logger.LogInformation("Received SyncStarted event");
+                if (OnSyncStarted != null)
+                {
+                    await OnSyncStarted.Invoke();
+                }
+            });
+
+            _hubConnection.On<SyncResultDto>("SyncCompleted", async (result) =>
+            {
+                _logger.LogInformation(
+                    "Received SyncCompleted event. Repos: {Repos}, Commits: {Commits}, PRs: {PRs}",
+                    result.RepositoriesSynced, result.CommitsSynced, result.PullRequestsSynced);
+                
+                if (OnSyncCompleted != null)
+                {
+                    await OnSyncCompleted.Invoke(result);
+                }
+            });
+
+            _hubConnection.On("MetricsUpdated", async (object data) =>
+            {
+                _logger.LogInformation("Received MetricsUpdated event");
+                if (OnMetricsUpdated != null)
+                {
+                    await OnMetricsUpdated.Invoke();
+                }
+            });
+
+            // Connection state handlers
+            _hubConnection.Reconnecting += error =>
+            {
+                _logger.LogWarning(error, "SignalR connection lost, attempting to reconnect...");
+                OnConnectionStateChanged?.Invoke(HubConnectionState.Reconnecting);
+                return Task.CompletedTask;
+            };
+
+            _hubConnection.Reconnected += async connectionId =>
+            {
+                _logger.LogInformation("SignalR reconnected with connection ID: {ConnectionId}", connectionId);
+                OnConnectionStateChanged?.Invoke(HubConnectionState.Connected);
+                
+                // Rejoin the dashboard group after reconnection
+                if (!string.IsNullOrEmpty(_currentUserId))
+                {
+                    await JoinDashboardAsync(_currentUserId);
+                }
+            };
+
+            _hubConnection.Closed += error =>
+            {
+                _logger.LogWarning(error, "SignalR connection closed");
+                OnConnectionStateChanged?.Invoke(HubConnectionState.Disconnected);
+                return Task.CompletedTask;
+            };
+
+            // Start connection
+            await _hubConnection.StartAsync();
+            _logger.LogInformation("SignalR connection started successfully");
+            OnConnectionStateChanged?.Invoke(HubConnectionState.Connected);
+
+            // Join the user's dashboard group
+            await JoinDashboardAsync(userId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to start SignalR connection");
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Join a user's dashboard group to receive their updates
+    /// </summary>
+    private async Task JoinDashboardAsync(string userId)
+    {
+        if (_hubConnection?.State == HubConnectionState.Connected)
+        {
+            await _hubConnection.InvokeAsync("JoinDashboard", userId);
+            _logger.LogInformation("Joined dashboard group for user {UserId}", userId);
+        }
+    }
+
+    /// <summary>
+    /// Leave the current dashboard group
+    /// </summary>
+    public async Task LeaveDashboardAsync()
+    {
+        if (_hubConnection?.State == HubConnectionState.Connected && !string.IsNullOrEmpty(_currentUserId))
+        {
+            await _hubConnection.InvokeAsync("LeaveDashboard", _currentUserId);
+            _logger.LogInformation("Left dashboard group for user {UserId}", _currentUserId);
+        }
+    }
+
+    /// <summary>
+    /// Stop the SignalR connection
+    /// </summary>
+    public async Task StopAsync()
+    {
+        if (_hubConnection != null)
+        {
+            await LeaveDashboardAsync();
+            await _hubConnection.StopAsync();
+            _logger.LogInformation("SignalR connection stopped");
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_hubConnection != null)
+        {
+            await LeaveDashboardAsync();
+            await _hubConnection.DisposeAsync();
+            _hubConnection = null;
+            _logger.LogInformation("SignalR connection disposed");
+        }
+    }
+}
+


### PR DESCRIPTION
- Add SignalRService with HubConnection management
- Add auto-reconnect with exponential backoff
- Update Home.razor with real-time sync indicators
- Handle SyncStarted/SyncCompleted/MetricsUpdated events
- Auto-refresh dashboard data on sync completion
- Add connection status indicator for disconnected state
- Add GetUserIdAsync to AuthStateService
- Install Microsoft.AspNetCore.SignalR.Client package

Closes #124

<!-- GitHub auto-fills description from commits below -->

## ✅ Ready to Merge?
- [x] Builds successfully
- [x] CI checks passing
- [x] Tested locally

