### PR TITLE
feat(dashboard): add global time range filter component

### DIFF
--- a/src/DevMetricsPro.Web/Components/Pages/Home.razor
+++ b/src/DevMetricsPro.Web/Components/Pages/Home.razor
@@ -9,11 +9,13 @@
 @using DevMetricsPro.Web.Services
 @using Microsoft.AspNetCore.SignalR.Client
 @implements IAsyncDisposable
+@implements IDisposable
 @inject AuthStateService AuthState
 @inject IChartDataService ChartDataService
 @inject ILeaderboardService LeaderboardService
 @inject IMetricsCalculationService MetricsService
 @inject SignalRService SignalR
+@inject DashboardStateService DashboardState
 @inject HttpClient Http
 @inject NavigationManager Navigation
 @inject ILogger<Home> Logger
@@ -54,6 +56,17 @@
 }
 else
 {
+    <!-- Global Time Range Selector - Phase 3.9 -->
+    <MudPaper Class="pa-3 mb-4" Elevation="1">
+        <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px;">
+            <MudText Typo="Typo.subtitle1" Style="font-weight: 600;">
+                <MudIcon Icon="@Icons.Material.Filled.FilterAlt" Size="Size.Small" Class="mr-2" />
+                Dashboard Filter
+            </MudText>
+            <TimeRangeSelector />
+        </div>
+    </MudPaper>
+
     <!-- Metrics Grid -->
     <div class="metrics-grid">
         <MetricCard 
@@ -85,31 +98,6 @@ else
     <MudPaper Class="pa-4 mt-4">
         <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
             <MudText Typo="Typo.h5">📈 Commit Activity</MudText>
-            
-            <!-- Time Range Selector -->
-            <div style="display: flex; gap: 8px;">
-                <MudButton 
-                    Size="Size.Small" 
-                    Variant="@(_selectedDays == 7 ? Variant.Filled : Variant.Outlined)"
-                    Color="Color.Primary"
-                    OnClick="() => LoadCommitActivityAsync(7)">
-                    7 Days
-                </MudButton>
-                <MudButton 
-                    Size="Size.Small" 
-                    Variant="@(_selectedDays == 30 ? Variant.Filled : Variant.Outlined)"
-                    Color="Color.Primary"
-                    OnClick="() => LoadCommitActivityAsync(30)">
-                    30 Days
-                </MudButton>
-                <MudButton 
-                    Size="Size.Small" 
-                    Variant="@(_selectedDays == 90 ? Variant.Filled : Variant.Outlined)"
-                    Color="Color.Primary"
-                    OnClick="() => LoadCommitActivityAsync(90)">
-                    90 Days
-                </MudButton>
-            </div>
         </div>
 
         @if (_isLoadingChart)
@@ -158,31 +146,6 @@ else
     <MudPaper Class="pa-4 mt-4">
         <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
             <MudText Typo="Typo.h5">🔀 Pull Request Statistics</MudText>
-            
-            <!-- Time Range Selector -->
-            <div style="display: flex; gap: 8px;">
-                <MudButton 
-                    Size="Size.Small" 
-                    Variant="@(_selectedPRDays == 7 ? Variant.Filled : Variant.Outlined)"
-                    Color="Color.Primary"
-                    OnClick="() => LoadPRStatsAsync(7)">
-                    7 Days
-                </MudButton>
-                <MudButton 
-                    Size="Size.Small" 
-                    Variant="@(_selectedPRDays == 30 ? Variant.Filled : Variant.Outlined)"
-                    Color="Color.Primary"
-                    OnClick="() => LoadPRStatsAsync(30)">
-                    30 Days
-                </MudButton>
-                <MudButton 
-                    Size="Size.Small" 
-                    Variant="@(_selectedPRDays == 90 ? Variant.Filled : Variant.Outlined)"
-                    Color="Color.Primary"
-                    OnClick="() => LoadPRStatsAsync(90)">
-                    90 Days
-                </MudButton>
-            </div>
         </div>
 
         @if (_isLoadingPRChart)
@@ -244,31 +207,6 @@ else
     <MudPaper Class="pa-4 mt-4">
         <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
             <MudText Typo="Typo.h5">🗓️ Contribution Activity</MudText>
-            
-            <!-- Week Range Selector -->
-            <div style="display: flex; gap: 8px;">
-                <MudButton 
-                    Size="Size.Small" 
-                    Variant="@(_selectedWeeks == 13 ? Variant.Filled : Variant.Outlined)"
-                    Color="Color.Primary"
-                    OnClick="() => LoadHeatmapAsync(13)">
-                    3 Months
-                </MudButton>
-                <MudButton 
-                    Size="Size.Small" 
-                    Variant="@(_selectedWeeks == 26 ? Variant.Filled : Variant.Outlined)"
-                    Color="Color.Primary"
-                    OnClick="() => LoadHeatmapAsync(26)">
-                    6 Months
-                </MudButton>
-                <MudButton 
-                    Size="Size.Small" 
-                    Variant="@(_selectedWeeks == 52 ? Variant.Filled : Variant.Outlined)"
-                    Color="Color.Primary"
-                    OnClick="() => LoadHeatmapAsync(52)">
-                    1 Year
-                </MudButton>
-            </div>
         </div>
 
         <ContributionHeatmap 
@@ -279,7 +217,7 @@ else
 
     <!-- Team Leaderboard - Phase 3.5 -->
     <MudPaper Class="pa-4 mt-4">
-        <MudText Typo="Typo.h5" Class="mb-4">🏆 Top Contributors (Last 30 Days)</MudText>
+        <MudText Typo="Typo.h5" Class="mb-4">🏆 Top Contributors (@DashboardState.GetRangeLabel())</MudText>
         
         <Leaderboard 
             Entries="@_leaderboardEntries"
@@ -471,17 +409,14 @@ else
     // Chart data - Phase 3.2
     private CommitActivityChartDto? _chartData;
     private bool _isLoadingChart = false;
-    private int _selectedDays = 7;
 
     // PR Chart data - Phase 3.3
     private PullRequestChartDto? _prChartData;
     private bool _isLoadingPRChart = false;
-    private int _selectedPRDays = 30;
 
     // Heatmap data - Phase 3.4
     private ContributionHeatmapDto? _heatmapData;
     private bool _isLoadingHeatmap = false;
-    private int _selectedWeeks = 52;
 
     // Leaderboard data - Phase 3.5
     private List<LeaderboardEntryDto>? _leaderboardEntries;
@@ -509,13 +444,14 @@ else
             // Get user ID for SignalR
             _currentUserId = await AuthState.GetUserIdAsync();
             
+            // Subscribe to global time range changes - Phase 3.9
+            DashboardState.OnStateChanged += HandleTimeRangeChanged;
+            
             await CheckGitHubConnectionStatus();
             await LoadRecentCommitsAsync();
-            await LoadCommitActivityAsync(7);
-            await LoadPRStatsAsync(30);
-            await LoadHeatmapAsync(52);
-            await LoadLeaderboardAsync(_selectedMetric);
-            await LoadAdvancedMetricsAsync();
+            
+            // Load all charts using global time range
+            await LoadAllChartsAsync();
 
             // Initialize SignalR connection
             await InitializeSignalRAsync();
@@ -529,6 +465,39 @@ else
             githubConnectedMessage = "GitHub account connected successfully!";
             await CheckGitHubConnectionStatus(); // Refresh status
         }
+    }
+
+    /// <summary>
+    /// Handler for global time range changes - Phase 3.9
+    /// </summary>
+    private async void HandleTimeRangeChanged()
+    {
+        await InvokeAsync(async () =>
+        {
+            Logger.LogInformation("Time range changed to: {Start} - {End}", 
+                DashboardState.StartDate, DashboardState.EndDate);
+            
+            // Reload all charts with new time range
+            await LoadAllChartsAsync();
+            StateHasChanged();
+        });
+    }
+
+    /// <summary>
+    /// Loads all chart data using the global time range
+    /// </summary>
+    private async Task LoadAllChartsAsync()
+    {
+        var tasks = new List<Task>
+        {
+            LoadCommitActivityAsync(),
+            LoadPRStatsAsync(),
+            LoadHeatmapAsync(),
+            LoadLeaderboardAsync(_selectedMetric),
+            LoadAdvancedMetricsAsync()
+        };
+
+        await Task.WhenAll(tasks);
     }
 
     private async Task InitializeSignalRAsync()
@@ -633,11 +602,7 @@ else
         var tasks = new List<Task>
         {
             LoadRecentCommitsAsync(),
-            LoadCommitActivityAsync(_selectedDays),
-            LoadPRStatsAsync(_selectedPRDays),
-            LoadHeatmapAsync(_selectedWeeks),
-            LoadLeaderboardAsync(_selectedMetric),
-            LoadAdvancedMetricsAsync()
+            LoadAllChartsAsync()
         };
 
         await Task.WhenAll(tasks);
@@ -658,13 +623,11 @@ else
 
         try
         {
-            var endDate = DateTime.UtcNow;
-            var startDate = endDate.AddDays(-30);
-
+            // Use global time range from DashboardState - Phase 3.9
             _reviewMetrics = await MetricsService.GetReviewTimeMetricsAsync(
                 developerId: null, // All developers
-                startDate: startDate,
-                endDate: endDate,
+                startDate: DashboardState.StartDate,
+                endDate: DashboardState.EndDate,
                 cancellationToken: default);
         }
         catch (Exception ex)
@@ -685,9 +648,13 @@ else
 
         try
         {
+            // Calculate weeks from global time range - Phase 3.9
+            var days = DashboardState.GetDaysInRange();
+            var weeks = days == int.MaxValue ? 12 : Math.Max(1, days / 7);
+            
             _velocityMetrics = await MetricsService.GetCodeVelocityAsync(
                 developerId: null, // All developers
-                numberOfWeeks: 12,
+                numberOfWeeks: weeks,
                 cancellationToken: default);
         }
         catch (Exception ex)
@@ -855,21 +822,18 @@ else
         Snackbar.Add(message ?? fallbackMessage, severity);
     }
 
-    private async Task LoadCommitActivityAsync(int days)
+    private async Task LoadCommitActivityAsync()
     {
-        _selectedDays = days;
         _isLoadingChart = true;
         StateHasChanged();
 
         try
         {
-            var endDate = DateTime.UtcNow;
-            var startDate = endDate.AddDays(-days);
-
+            // Use global time range from DashboardState - Phase 3.9
             _chartData = await ChartDataService.GetCommitActivityAsync(
                 developerId: null, // null = all developers
-                startDate: startDate,
-                endDate: endDate,
+                startDate: DashboardState.StartDate,
+                endDate: DashboardState.EndDate,
                 cancellationToken: default);
         }
         catch (Exception ex)
@@ -884,14 +848,17 @@ else
         }
     }
 
-    private async Task LoadPRStatsAsync(int days)
+    private async Task LoadPRStatsAsync()
     {
-        _selectedPRDays = days;
         _isLoadingPRChart = true;
         StateHasChanged();
 
         try
         {
+            // Use global time range from DashboardState - Phase 3.9
+            var days = DashboardState.GetDaysInRange();
+            if (days == int.MaxValue) days = 365; // Cap at 1 year for "All Time"
+            
             _prChartData = await ChartDataService.GetPullRequestStatsAsync(
                 days: days,
                 cancellationToken: default);
@@ -908,14 +875,17 @@ else
         }
     }
 
-    private async Task LoadHeatmapAsync(int weeks)
+    private async Task LoadHeatmapAsync()
     {
-        _selectedWeeks = weeks;
         _isLoadingHeatmap = true;
         StateHasChanged();
 
         try
         {
+            // Calculate weeks from global time range - Phase 3.9
+            var days = DashboardState.GetDaysInRange();
+            var weeks = days == int.MaxValue ? 52 : Math.Max(1, days / 7);
+            
             _heatmapData = await ChartDataService.GetContributionHeatmapAsync(
                 numberOfWeeks: weeks,
                 cancellationToken: default);
@@ -940,14 +910,12 @@ else
 
         try
         {
-            var endDate = DateTime.UtcNow;
-            var startDate = endDate.AddDays(-30); // Last 30 days
-
+            // Use global time range from DashboardState - Phase 3.9
             _leaderboardEntries = await LeaderboardService.GetLeaderboardAsync(
                 metric: metric,
                 topN: 10,
-                startDate: startDate,
-                endDate: endDate,
+                startDate: DashboardState.StartDate,
+                endDate: DashboardState.EndDate,
                 cancellationToken: default);
         }
         catch (Exception ex)
@@ -1000,6 +968,12 @@ else
         public int LinesRemoved { get; set; }
     }
 
+    public void Dispose()
+    {
+        // Unsubscribe from dashboard state changes - Phase 3.9
+        DashboardState.OnStateChanged -= HandleTimeRangeChanged;
+    }
+
     public async ValueTask DisposeAsync()
     {
         // Unregister event handlers
@@ -1007,6 +981,9 @@ else
         SignalR.OnSyncCompleted -= HandleSyncCompleted;
         SignalR.OnMetricsUpdated -= HandleMetricsUpdated;
         SignalR.OnConnectionStateChanged -= HandleConnectionStateChanged;
+        
+        // Unsubscribe from dashboard state - Phase 3.9
+        DashboardState.OnStateChanged -= HandleTimeRangeChanged;
 
         // Note: Don't dispose SignalR service here as it's managed by DI
         // Just leave the dashboard group

--- a/src/DevMetricsPro.Web/Components/Shared/TimeRangeSelector.razor
+++ b/src/DevMetricsPro.Web/Components/Shared/TimeRangeSelector.razor
@@ -1,0 +1,102 @@
+@using DevMetricsPro.Web.Services
+@inject DashboardStateService DashboardState
+@implements IDisposable
+
+<div class="time-range-selector">
+    <div class="preset-buttons">
+        <button class="preset-btn @GetActiveClass(TimeRangePreset.Last7Days)" 
+                @onclick="() => SelectPreset(TimeRangePreset.Last7Days)">
+            7D
+        </button>
+        <button class="preset-btn @GetActiveClass(TimeRangePreset.Last30Days)" 
+                @onclick="() => SelectPreset(TimeRangePreset.Last30Days)">
+            30D
+        </button>
+        <button class="preset-btn @GetActiveClass(TimeRangePreset.Last90Days)" 
+                @onclick="() => SelectPreset(TimeRangePreset.Last90Days)">
+            90D
+        </button>
+        <button class="preset-btn @GetActiveClass(TimeRangePreset.Last365Days)" 
+                @onclick="() => SelectPreset(TimeRangePreset.Last365Days)">
+            1Y
+        </button>
+        <button class="preset-btn @GetActiveClass(TimeRangePreset.AllTime)" 
+                @onclick="() => SelectPreset(TimeRangePreset.AllTime)">
+            All
+        </button>
+    </div>
+    
+    @if (ShowCustomPicker)
+    {
+        <div class="custom-picker">
+            <MudDateRangePicker 
+                Label="Custom Range"
+                DateRange="_dateRange"
+                DateRangeChanged="OnCustomRangeChanged"
+                Variant="Variant.Outlined"
+                Margin="Margin.Dense"
+                Class="custom-date-picker" />
+        </div>
+    }
+    
+    <div class="range-label">
+        <MudIcon Icon="@Icons.Material.Filled.DateRange" Size="Size.Small" />
+        <span>@DashboardState.GetRangeLabel()</span>
+    </div>
+</div>
+
+@code {
+    /// <summary>
+    /// Whether to show the custom date range picker
+    /// </summary>
+    [Parameter]
+    public bool ShowCustomPicker { get; set; } = false;
+
+    /// <summary>
+    /// Callback when time range changes (optional - state service handles most cases)
+    /// </summary>
+    [Parameter]
+    public EventCallback OnRangeChanged { get; set; }
+
+    private DateRange? _dateRange;
+
+    protected override void OnInitialized()
+    {
+        // Subscribe to state changes to update UI
+        DashboardState.OnStateChanged += HandleStateChanged;
+        
+        // Initialize date range picker with current values
+        _dateRange = new DateRange(DashboardState.StartDate, DashboardState.EndDate);
+    }
+
+    private void SelectPreset(TimeRangePreset preset)
+    {
+        DashboardState.SetTimeRange(preset);
+        _dateRange = new DateRange(DashboardState.StartDate, DashboardState.EndDate);
+    }
+
+    private async Task OnCustomRangeChanged(DateRange? range)
+    {
+        if (range?.Start.HasValue == true && range?.End.HasValue == true)
+        {
+            DashboardState.SetCustomRange(range.Start.Value, range.End.Value);
+            await OnRangeChanged.InvokeAsync();
+        }
+    }
+
+    private string GetActiveClass(TimeRangePreset preset)
+    {
+        return DashboardState.SelectedPreset == preset ? "active" : "";
+    }
+
+    private void HandleStateChanged()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        DashboardState.OnStateChanged -= HandleStateChanged;
+    }
+}
+

--- a/src/DevMetricsPro.Web/Components/Shared/TimeRangeSelector.razor.css
+++ b/src/DevMetricsPro.Web/Components/Shared/TimeRangeSelector.razor.css
@@ -1,0 +1,93 @@
+.time-range-selector {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.preset-buttons {
+    display: flex;
+    gap: 0.25rem;
+    background: var(--mud-palette-background-grey, #f5f5f5);
+    border-radius: 8px;
+    padding: 4px;
+}
+
+.preset-btn {
+    padding: 0.5rem 1rem;
+    border: none;
+    background: transparent;
+    color: var(--mud-palette-text-secondary, #666);
+    font-size: 0.875rem;
+    font-weight: 500;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    min-width: 48px;
+}
+
+.preset-btn:hover {
+    background: var(--mud-palette-action-default-hover, rgba(0,0,0,0.04));
+    color: var(--mud-palette-text-primary, #333);
+}
+
+.preset-btn.active {
+    background: var(--mud-palette-primary, #594ae2);
+    color: white;
+    box-shadow: 0 2px 4px rgba(89, 74, 226, 0.3);
+}
+
+.preset-btn.active:hover {
+    background: var(--mud-palette-primary-darken, #4a3bc7);
+    color: white;
+}
+
+.custom-picker {
+    min-width: 200px;
+}
+
+::deep .custom-date-picker {
+    margin: 0;
+}
+
+::deep .custom-date-picker .mud-input-slot {
+    font-size: 0.875rem;
+}
+
+.range-label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--mud-palette-text-secondary, #666);
+    font-size: 0.875rem;
+    padding: 0.5rem 0.75rem;
+    background: var(--mud-palette-surface, #fff);
+    border-radius: 6px;
+    border: 1px solid var(--mud-palette-lines-default, #e0e0e0);
+}
+
+.range-label span {
+    white-space: nowrap;
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+    .time-range-selector {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    
+    .preset-buttons {
+        justify-content: center;
+    }
+    
+    .preset-btn {
+        padding: 0.5rem 0.75rem;
+        min-width: 40px;
+    }
+    
+    .range-label {
+        justify-content: center;
+    }
+}
+

--- a/src/DevMetricsPro.Web/Program.cs
+++ b/src/DevMetricsPro.Web/Program.cs
@@ -172,6 +172,9 @@ try
     builder.Services.AddScoped<IMetricsHubService, MetricsHubService>();
     builder.Services.AddScoped<SignalRService>();
 
+    // Dashboard state management (global time range filter)
+    builder.Services.AddScoped<DashboardStateService>();
+
     // Configure application cookie
     builder.Services.ConfigureApplicationCookie(options =>
     {

--- a/src/DevMetricsPro.Web/Services/DashboardStateService.cs
+++ b/src/DevMetricsPro.Web/Services/DashboardStateService.cs
@@ -1,0 +1,131 @@
+namespace DevMetricsPro.Web.Services;
+
+/// <summary>
+/// Manages global dashboard state including time range filters.
+/// Registered as Scoped service so state persists within user session.
+/// </summary>
+public class DashboardStateService : IDisposable
+{
+    private DateTime _startDate;
+    private DateTime _endDate;
+    private TimeRangePreset _selectedPreset;
+    private bool _disposed;
+
+    /// <summary>
+    /// Event fired when dashboard state changes. Components should subscribe to this.
+    /// </summary>
+    public event Action? OnStateChanged;
+
+    public DashboardStateService()
+    {
+        // Default to 30 days
+        _selectedPreset = TimeRangePreset.Last30Days;
+        _endDate = DateTime.UtcNow.Date;
+        _startDate = _endDate.AddDays(-30);
+    }
+
+    /// <summary>
+    /// Current start date for filtering
+    /// </summary>
+    public DateTime StartDate => _startDate;
+
+    /// <summary>
+    /// Current end date for filtering
+    /// </summary>
+    public DateTime EndDate => _endDate;
+
+    /// <summary>
+    /// Currently selected preset
+    /// </summary>
+    public TimeRangePreset SelectedPreset => _selectedPreset;
+
+    /// <summary>
+    /// Sets the time range using a preset
+    /// </summary>
+    public void SetTimeRange(TimeRangePreset preset)
+    {
+        _selectedPreset = preset;
+        _endDate = DateTime.UtcNow.Date;
+
+        _startDate = preset switch
+        {
+            TimeRangePreset.Last7Days => _endDate.AddDays(-7),
+            TimeRangePreset.Last30Days => _endDate.AddDays(-30),
+            TimeRangePreset.Last90Days => _endDate.AddDays(-90),
+            TimeRangePreset.Last365Days => _endDate.AddDays(-365),
+            TimeRangePreset.AllTime => DateTime.MinValue,
+            TimeRangePreset.Custom => _startDate, // Keep existing start date for custom
+            _ => _endDate.AddDays(-30)
+        };
+
+        NotifyStateChanged();
+    }
+
+    /// <summary>
+    /// Sets a custom date range
+    /// </summary>
+    public void SetCustomRange(DateTime startDate, DateTime endDate)
+    {
+        _selectedPreset = TimeRangePreset.Custom;
+        _startDate = startDate.Date;
+        _endDate = endDate.Date;
+
+        NotifyStateChanged();
+    }
+
+    /// <summary>
+    /// Gets the number of days in the current range
+    /// </summary>
+    public int GetDaysInRange()
+    {
+        if (_selectedPreset == TimeRangePreset.AllTime)
+            return int.MaxValue;
+
+        return (int)(_endDate - _startDate).TotalDays;
+    }
+
+    /// <summary>
+    /// Gets user-friendly label for current range
+    /// </summary>
+    public string GetRangeLabel()
+    {
+        return _selectedPreset switch
+        {
+            TimeRangePreset.Last7Days => "Last 7 Days",
+            TimeRangePreset.Last30Days => "Last 30 Days",
+            TimeRangePreset.Last90Days => "Last 90 Days",
+            TimeRangePreset.Last365Days => "Last Year",
+            TimeRangePreset.AllTime => "All Time",
+            TimeRangePreset.Custom => $"{_startDate:MMM d} - {_endDate:MMM d, yyyy}",
+            _ => "Last 30 Days"
+        };
+    }
+
+    private void NotifyStateChanged()
+    {
+        OnStateChanged?.Invoke();
+    }
+
+    public void Dispose()
+    {
+        if (!_disposed)
+        {
+            OnStateChanged = null;
+            _disposed = true;
+        }
+    }
+}
+
+/// <summary>
+/// Preset time ranges for quick selection
+/// </summary>
+public enum TimeRangePreset
+{
+    Last7Days,
+    Last30Days,
+    Last90Days,
+    Last365Days,
+    AllTime,
+    Custom
+}
+


### PR DESCRIPTION
- Create DashboardStateService for managing global time range state
- Create TimeRangeSelector component with preset buttons (7D/30D/90D/1Y/All)
- Add custom date range picker option
- Update Home.razor to subscribe to state changes
- All charts now respond to global time range filter
- Remove individual chart time selectors for cleaner UX
- Leaderboard title shows dynamic date range

Closes #129

<!-- GitHub auto-fills description from commits below -->

## ✅ Ready to Merge?
- [x] Builds successfully
- [x] CI checks passing
- [x] Tested locally

